### PR TITLE
server: a new package of re-usable server infrasturctures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 lib/
 lib-lite/
 *.log
+*.tsbuildinfo
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ Type safe interactions with Canton node via [JSON API](https://docs.digitalasset
 - [C7/Ledger](ledger/README.md)
 - [C7/React](react/README.md)
 - [C7/Scribe](scribe/README.md)
+- [C7/Server](server/README.md)
 
 - Current version: 0.0.1, Daml/Canton Target: 3.4.9

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@c7-digital/monorepo",
   "version": "0.0.9",
   "private": true,
-  "description": "Monorepo containing @c7-digital/ledger, @c7-digital/react, and @c7-digital/scribe packages",
+  "description": "Monorepo containing @c7-digital/ledger, @c7-digital/react, @c7-digital/scribe, and @c7-digital/server packages",
   "scripts": {
     "build": "pnpm -r build",
     "clean": "pnpm -r clean",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@18.19.130)(tsx@4.21.0)(yaml@2.8.2)
 
+  server:
+    dependencies:
+      '@daml/types':
+        specifier: 3.4.9
+        version: 3.4.9
+      jose:
+        specifier: ^6.0.10
+        version: 6.1.3
+      keycloak-connect:
+        specifier: ^26.1.1
+        version: 26.1.1
+      zod:
+        specifier: ^3.24.3
+        version: 3.25.76
+    devDependencies:
+      '@c7-digital/ledger':
+        specifier: workspace:*
+        version: link:../ledger
+      '@types/node':
+        specifier: ^18.15.11
+        version: 18.19.130
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
 packages:
 
   '@babel/code-frame@7.29.0':
@@ -897,79 +922,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1015,6 +1027,12 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@testim/chrome-version@1.1.4':
+    resolution: {integrity: sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@types/ajv@0.0.5':
     resolution: {integrity: sha512-0UD98SZLwPk6cTMZoLs8W4XSAWgqT9nyoZiBw+uXEPf1u5h+Dn2ztMG4Is9pDA+9D7GKbCTfIkQK/hNgoWVQcQ==}
@@ -1087,6 +1105,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -1176,9 +1197,22 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1212,9 +1246,16 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  basic-ftp@5.2.0:
+    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+    engines: {node: '>=10.0.0'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1225,6 +1266,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1238,8 +1282,15 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1275,6 +1326,11 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chromedriver@145.0.5:
+    resolution: {integrity: sha512-cpDmNRmjTSM5xYV7Xov+SihjtP0PYxDZllLPbuQ0zpBeV79JTyB69b7yoUR+cLD35PIosfMzRMzXZ9yXKOP2oQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -1307,12 +1363,19 @@ packages:
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1334,6 +1397,19 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1359,6 +1435,14 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -1371,11 +1455,18 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1387,11 +1478,30 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1414,6 +1524,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -1491,6 +1606,11 @@ packages:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1512,6 +1632,9 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1545,9 +1668,22 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1568,9 +1704,21 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1578,6 +1726,10 @@ packages:
 
   get-tsconfig@4.13.1:
     resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1604,6 +1756,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1616,12 +1772,30 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1658,6 +1832,14 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-regex@4.3.0:
+    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
+    engines: {node: '>=8'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1699,6 +1881,13 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
+  is2@2.0.9:
+    resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
+    engines: {node: '>=v0.10.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1931,6 +2120,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jwk-to-pem@2.0.7:
+    resolution: {integrity: sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==}
+
+  keycloak-connect@26.1.1:
+    resolution: {integrity: sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==}
+    engines: {node: '>=14'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1980,6 +2176,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1993,6 +2193,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -2004,9 +2208,23 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2026,6 +2244,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2043,6 +2264,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -2107,6 +2332,14 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -2147,6 +2380,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2194,6 +2430,19 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.0.0:
+    resolution: {integrity: sha512-h2lD3OfRraP3R51rNFKIE8nX+qoLr1mE74X91YhVxtDbt+OD6ntoNZv56+JgI4RCdtwQ5eexsOk1KdOQDfvPCQ==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2264,6 +2513,12 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2302,6 +2557,18 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2375,6 +2642,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tcp-port-used@1.0.2:
+    resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -2435,6 +2705,9 @@ packages:
     resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
     engines: {node: '>=16.20.2'}
     hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -2663,6 +2936,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3460,6 +3736,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testim/chrome-version@1.1.4':
+    optional: true
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    optional: true
+
   '@types/ajv@0.0.5': {}
 
   '@types/babel__core@7.20.5':
@@ -3541,6 +3823,11 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 18.19.130
+    optional: true
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3627,7 +3914,31 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  asynckit@0.4.0:
+    optional: true
+
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    optional: true
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -3688,7 +3999,12 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
+  basic-ftp@5.2.0:
+    optional: true
+
   binary-extensions@2.3.0: {}
+
+  bn.js@4.12.3: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -3702,6 +4018,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brorand@1.1.0: {}
 
   browserslist@4.28.1:
     dependencies:
@@ -3719,7 +4037,16 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-crc32@0.2.13:
+    optional: true
+
   buffer-from@1.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    optional: true
 
   callsites@3.1.0: {}
 
@@ -3752,6 +4079,20 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chromedriver@145.0.5:
+    dependencies:
+      '@testim/chrome-version': 1.1.4
+      axios: 1.13.5
+      compare-versions: 6.1.1
+      extract-zip: 2.0.1
+      proxy-agent: 6.5.0
+      proxy-from-env: 2.0.0
+      tcp-port-used: 1.0.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    optional: true
+
   ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
@@ -3776,9 +4117,17 @@ snapshots:
 
   colorette@1.4.0: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+    optional: true
+
   commander@9.5.0: {}
 
   commondir@1.0.1: {}
+
+  compare-versions@6.1.1:
+    optional: true
 
   concat-map@0.0.1: {}
 
@@ -3813,6 +4162,14 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@6.0.2:
+    optional: true
+
+  debug@4.3.1:
+    dependencies:
+      ms: 2.1.2
+    optional: true
+
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -3825,6 +4182,16 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+    optional: true
+
+  delayed-stream@1.0.0:
+    optional: true
+
   detect-newline@3.1.0: {}
 
   diff-sequences@29.6.3: {}
@@ -3833,9 +4200,26 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.286: {}
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   emittery@0.13.1: {}
 
@@ -3843,11 +4227,35 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1:
+    optional: true
+
+  es-errors@1.3.0:
+    optional: true
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+    optional: true
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3909,6 +4317,15 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+    optional: true
 
   eslint-scope@8.4.0:
     dependencies:
@@ -4019,6 +4436,17 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -4042,6 +4470,11 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+    optional: true
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -4072,10 +4505,22 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11:
+    optional: true
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -4088,13 +4533,47 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    optional: true
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+    optional: true
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.3
+    optional: true
 
   get-stream@6.0.1: {}
 
   get-tsconfig@4.13.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.2.0
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -4133,6 +4612,9 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0:
+    optional: true
+
   graceful-fs@4.2.11: {}
 
   handlebars@4.7.8:
@@ -4146,11 +4628,38 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0:
+    optional: true
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+    optional: true
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -4184,6 +4693,12 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ip-address@10.1.0:
+    optional: true
+
+  ip-regex@4.3.0:
+    optional: true
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -4213,6 +4728,16 @@ snapshots:
       '@types/estree': 1.0.8
 
   is-stream@2.0.1: {}
+
+  is-url@1.2.4:
+    optional: true
+
+  is2@2.0.9:
+    dependencies:
+      deep-is: 0.1.4
+      ip-regex: 4.3.0
+      is-url: 1.2.4
+    optional: true
 
   isexe@2.0.0: {}
 
@@ -4647,6 +5172,21 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jwk-to-pem@2.0.7:
+    dependencies:
+      asn1.js: 5.4.1
+      elliptic: 6.6.1
+      safe-buffer: 5.2.1
+
+  keycloak-connect@26.1.1:
+    dependencies:
+      jwk-to-pem: 2.0.7
+    optionalDependencies:
+      chromedriver: 145.0.5
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -4688,6 +5228,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3:
+    optional: true
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4702,6 +5245,9 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  math-intrinsics@1.1.0:
+    optional: true
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -4711,7 +5257,19 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0:
+    optional: true
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+    optional: true
+
   mimic-fn@2.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -4729,6 +5287,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  ms@2.1.2:
+    optional: true
+
   ms@2.1.3: {}
 
   mylas@2.1.14: {}
@@ -4738,6 +5299,9 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  netmask@2.0.2:
+    optional: true
 
   node-fetch@2.7.0:
     dependencies:
@@ -4800,6 +5364,26 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
+    optional: true
+
   package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
@@ -4835,6 +5419,9 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -4878,6 +5465,32 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  proxy-from-env@1.1.0:
+    optional: true
+
+  proxy-from-env@2.0.0:
+    optional: true
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -4956,6 +5569,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
@@ -4977,6 +5594,24 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -5040,6 +5675,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tcp-port-used@1.0.2:
+    dependencies:
+      debug: 4.3.1
+      is2: 2.0.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -5094,6 +5737,9 @@ snapshots:
       mylas: 2.1.14
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:
@@ -5259,6 +5905,12 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@18.19.130)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'react'
   - 'scribe'
   - 'scan'
+  - 'server'
 
 settings:
   inject-workspace-packages: true

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,8 +7,9 @@ const LEDGER_PACKAGE_PATH = 'ledger/package.json';
 const REACT_PACKAGE_PATH = 'react/package.json';
 const SCRIBE_PACKAGE_PATH = 'scribe/package.json';
 const SCAN_PACKAGE_PATH = 'scan/package.json';
+const SERVER_PACKAGE_PATH = 'server/package.json';
 
-type PackageSelection = 'ledger' | 'react' | 'scribe' | 'scan' | 'all';
+type PackageSelection = 'ledger' | 'react' | 'scribe' | 'scan' | 'server' | 'all';
 
 function exec(command: string, options = {}) {
   return execSync(command, { stdio: 'inherit', ...options });
@@ -43,9 +44,9 @@ function parsePackageSelection(): PackageSelection {
 
   const value = args[packageIndex + 1] as PackageSelection;
 
-  if (!value || !['ledger', 'react', 'scribe', 'scan', 'all'].includes(value)) {
+  if (!value || !['ledger', 'react', 'scribe', 'scan', 'server', 'all'].includes(value)) {
     console.error(`Invalid --package value: ${value || 'none'}`);
-    console.error('Valid options: ledger, react, scribe, scan, all');
+    console.error('Valid options: ledger, react, scribe, scan, server, all');
     process.exit(1);
   }
 
@@ -75,6 +76,7 @@ async function main() {
   const releasingReact = packageSelection === 'react' || packageSelection === 'all';
   const releasingScribe = packageSelection === 'scribe' || packageSelection === 'all';
   const releasingScan = packageSelection === 'scan' || packageSelection === 'all';
+  const releasingServer = packageSelection === 'server' || packageSelection === 'all';
 
   // Display what will be released
   if (packageSelection === 'all') {
@@ -88,10 +90,12 @@ async function main() {
   const reactPkg = readPackageJson(REACT_PACKAGE_PATH);
   const scribePkg = readPackageJson(SCRIBE_PACKAGE_PATH);
   const scanPkg = readPackageJson(SCAN_PACKAGE_PATH);
+  const serverPkg = readPackageJson(SERVER_PACKAGE_PATH);
   const ledgerVersion = ledgerPkg.version;
   const reactVersion = reactPkg.version;
   const scribeVersion = scribePkg.version;
   const scanVersion = scanPkg.version;
+  const serverVersion = serverPkg.version;
 
   
   // Confirm versions have been updated
@@ -152,6 +156,9 @@ async function main() {
   if (releasingScan) {
     console.log(`  - @c7-digital/scan@${scanVersion}`);
   }
+  if (releasingServer) {
+    console.log(`  - @c7-digital/server@${serverVersion}`);
+  }
   console.log('');
 
   // Confirm with user
@@ -209,12 +216,24 @@ async function main() {
     }
   }
 
+  if (releasingServer) {
+    console.log(`Publishing @c7-digital/server@${serverVersion}...`);
+    try {
+      exec(`npm publish --access public`, { cwd: resolve(process.cwd(), 'server') });
+      console.log(`✓ Published @c7-digital/server\n`);
+    } catch (error) {
+      console.error(`✗ Failed to publish @c7-digital/server`);
+      process.exit(1);
+    }
+  }
+
   // Final success message
   const publishedPackages: string[] = [];
   if (releasingLedger) publishedPackages.push(`@c7-digital/ledger@${ledgerVersion}`);
   if (releasingReact) publishedPackages.push(`@c7-digital/react@${reactVersion}`);
   if (releasingScribe) publishedPackages.push(`@c7-digital/scribe@${scribeVersion}`);
   if (releasingScan) publishedPackages.push(`@c7-digital/scan@${scanVersion}`);
+  if (releasingServer) publishedPackages.push(`@c7-digital/server@${serverVersion}`);
 
   console.log(`Done! Published ${publishedPackages.join(' and ')}`);
 }

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,231 @@
+# @c7-digital/server
+
+Server infrastructure for Canton Network applications. Provides the core services that every Canton API backend needs: contract streaming, Keycloak identity management, structured logging, and auth utilities.
+
+## Installation
+
+```bash
+pnpm add @c7-digital/server
+```
+
+Peer dependency: `@c7-digital/ledger >= 0.0.8`
+
+## Overview
+
+| Export | Description |
+|--------|-------------|
+| `ActiveContractsService` | Streams and caches contracts from the Canton ledger via MultiStream |
+| `TemplateTracker` | Per-template contract map with create/archive callbacks |
+| `InterfaceTracker` | Per-interface view map with view/archive callbacks |
+| `IdentityService` | Keycloak token lifecycle with auto-refresh and heartbeat monitoring |
+| `Logger` / `LedgerLoggerAdapter` | Structured JSON logging to stdout/stderr |
+| `@c7-digital/server/auth` | Isomorphic (browser + Node) auth payload encode/decode utilities |
+
+## ActiveContractsService
+
+Maintains an in-memory cache of active contracts by streaming updates from the Canton JSON API. Register templates and interfaces before initialization, then access their payloads through type-safe trackers.
+
+```typescript
+import {
+  ActiveContractsService,
+  TemplateTracker,
+} from "@c7-digital/server";
+import { lookupTemplate } from "@my-app/codegen";
+
+const acs = new ActiveContractsService({
+  ledgerUrl: "http://localhost:7575",
+  versionedRegistry: lookupTemplate,
+});
+
+// Register templates before init
+const tokenTracker = acs.registerTemplate(MyToken);
+
+// Optionally register interfaces
+const viewTracker = acs.registerInterface(MyInterface);
+
+// Set up callbacks
+tokenTracker.onContractCreated((contractId, payload, createEvent) => {
+  console.log("New contract:", contractId);
+});
+
+tokenTracker.onContractArchived((contractId) => {
+  console.log("Archived:", contractId);
+});
+
+// Initialize with a ledger token
+await acs.initWithToken(token);
+
+// Access cached contracts
+const allContracts = acs.getAllPayloads(MyToken);
+const single = acs.getPayload(MyToken, contractId);
+const count = acs.getContractCount(MyToken);
+```
+
+### Constructor Options
+
+```typescript
+interface ActiveContractsServiceOptions {
+  ledgerUrl?: string;              // Canton JSON API URL
+  versionedRegistry: VersionedRegistry; // From scribe-generated codegen
+  logger?: AcsLogger;              // Optional structured logger
+}
+```
+
+### GC Safety
+
+The service maintains strong references to all active streams via internal `Set` collections, preventing garbage collection. For streams created outside the main MultiStream, use `addStreamReference()` and `removeStreamReference()`.
+
+### Custom Logger
+
+Inject a logger matching the `AcsLogger` interface:
+
+```typescript
+interface AcsLogger {
+  info(message: string, context?: Record<string, any>): void;
+  warn(message: string, context?: Record<string, any>): void;
+  error(message: string, error?: Error | Record<string, any>): void;
+  debug(message: string, context?: Record<string, any>): void;
+}
+```
+
+If no logger is provided, a no-op logger is used.
+
+## IdentityService
+
+Manages the Keycloak token lifecycle for service-to-service (client credentials) authentication. Handles initial token fetch, automatic refresh before expiry, retry with exponential backoff, and a heartbeat monitor that catches missed refreshes.
+
+```typescript
+import { IdentityService, Logger } from "@c7-digital/server";
+
+const logger = new Logger();
+const identity = new IdentityService(
+  {
+    url: "https://keycloak.example.com",
+    realm: "canton",
+    clientId: "my-api",
+    clientSecret: "secret",
+  },
+  logger
+);
+
+// Register callbacks before init
+identity.onTokenUpdate("acs", async (newToken) => {
+  await acs.initWithToken(newToken);
+});
+
+// Initialize (fetches first token, starts refresh cycle)
+await identity.init();
+
+// Or use a static token for local development
+await identity.initWithStaticToken(staticToken);
+
+// Access token
+const token = identity.getToken();
+const status = identity.getStatus();
+
+// Clean shutdown
+await identity.destroy();
+```
+
+### Key Features
+
+- **Auto-refresh**: Schedules token refresh at `min(expiresIn - 60s, expiresIn / 2)` before expiry
+- **Heartbeat monitor**: 30-second interval that catches missed scheduled refreshes
+- **Retry with backoff**: Up to 3 attempts with exponential backoff on token fetch failure
+- **Static token mode**: `initWithStaticToken()` bypasses Keycloak for local/sandbox development
+- **Token callbacks**: Register multiple services to be notified on token change via `onTokenUpdate()`
+
+## Logger
+
+Structured JSON logger that writes to stdout (all levels) and stderr (WARN/ERROR). Includes depth-limited object serialization to prevent oversized log entries.
+
+```typescript
+import { Logger, LedgerLoggerAdapter, limitObjectDepth } from "@c7-digital/server";
+
+const logger = new Logger();
+
+logger.info("Server started", { port: 3002 });
+logger.error("Connection failed", new Error("timeout"), { url: "..." });
+
+// Adapter for @c7-digital/ledger's Logger interface
+const ledgerLogger = new LedgerLoggerAdapter(logger);
+
+// Utility: limit nested object depth (default 6 levels)
+const safe = limitObjectDepth(deeplyNestedObject);
+```
+
+### Log Format
+
+```json
+{
+  "@timestamp": "2025-01-15T10:30:00.000Z",
+  "level": "INFO",
+  "message": "Server started",
+  "port": 3002
+}
+```
+
+## Auth Utilities
+
+Isomorphic (browser + Node.js) utilities for encoding and decoding typed auth payloads as base64 Bearer tokens. Available via the `@c7-digital/server/auth` subpath export.
+
+```typescript
+import {
+  encodeAuthPayload,
+  decodeAuthPayload,
+  createAdminAuth,
+  createContractAuth,
+  isAdminAuth,
+  isContractAuth,
+  getAuthPayloadFromRequest,
+} from "@c7-digital/server/auth";
+
+// Encode for use in Authorization header
+const token = createAdminAuth("my-api-key");
+// -> base64 of {"type":"admin","apiKey":"my-api-key"}
+
+const contractToken = createContractAuth(contractId, party);
+// -> base64 of {"type":"contract","contractId":"...","party":"..."}
+
+// Decode from Authorization: Bearer <token>
+const result = getAuthPayloadFromRequest(req);
+if (result.success && isAdminAuth(result.data)) {
+  // result.data.apiKey
+}
+```
+
+### Payload Types
+
+Two discriminated union variants:
+
+| Type | Fields | Use Case |
+|------|--------|----------|
+| `AdminAuthPayload` | `type: "admin"`, `apiKey` | Admin API authentication |
+| `ContractAuthPayload` | `type: "contract"`, `contractId`, `party` | Contract-scoped operations |
+
+All payloads are validated at encode and decode time using Zod schemas.
+
+## sha256
+
+Simple hash utility used internally by IdentityService to redact secrets in logs.
+
+```typescript
+import { sha256 } from "@c7-digital/server";
+
+const hash = sha256("my-secret"); // hex string
+```
+
+## Subpath Exports
+
+| Import Path | Contents |
+|-------------|----------|
+| `@c7-digital/server` | All services, logger, sha256, ACS types |
+| `@c7-digital/server/auth` | Auth encode/decode utilities (browser-safe, no Node.js deps) |
+
+## Dependencies
+
+- `@c7-digital/ledger` (peer) — Canton JSON API client
+- `@daml/types` — Daml type system
+- `keycloak-connect` — Keycloak token management
+- `jose` — JWT decoding
+- `zod` — Auth payload validation

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "tsc"
   },
   "dependencies": {
@@ -42,7 +44,8 @@
   "devDependencies": {
     "@c7-digital/ledger": "workspace:*",
     "@types/node": "^18.15.11",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.18"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@c7-digital/server",
+  "version": "0.0.9",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "description": "Server infrastructure for Canton Network applications",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./auth": {
+      "import": "./dist/auth/index.js",
+      "types": "./dist/auth/index.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "auth": ["dist/auth/index.d.ts"]
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepare": "tsc"
+  },
+  "dependencies": {
+    "@daml/types": "3.4.9",
+    "jose": "^6.0.10",
+    "keycloak-connect": "^26.1.1",
+    "zod": "^3.24.3"
+  },
+  "peerDependencies": {
+    "@c7-digital/ledger": ">=0.0.8"
+  },
+  "devDependencies": {
+    "@c7-digital/ledger": "workspace:*",
+    "@types/node": "^18.15.11",
+    "typescript": "^5.8.3"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "pnpm": ">=8.0.0"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/server",
-  "version": "0.0.9",
+  "version": "0.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/src/__tests__/acs/activeContractsService.test.ts
+++ b/server/src/__tests__/acs/activeContractsService.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMockLogger,
+  createMockTemplate,
+  createMockInterfaceCompanion,
+} from "../helpers/mocks.js";
+
+// Use vi.hoisted so these are available inside the hoisted vi.mock() factory
+const { mockMultiStream, mockInterfaceMultiStream, mockLedgerInstance, MockLedger } = vi.hoisted(() => {
+  const mockMultiStream = {
+    onState: vi.fn(),
+    onCreate: vi.fn(),
+    onArchive: vi.fn(),
+    onError: vi.fn(),
+    start: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const mockInterfaceMultiStream = {
+    onState: vi.fn(),
+    onInterfaceView: vi.fn(),
+    onArchive: vi.fn(),
+    onError: vi.fn(),
+    start: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const mockLedgerInstance = {
+    getTokenUserInfo: vi.fn().mockResolvedValue({
+      rights: [
+        { type: "canReadAs", party: "Alice" },
+        { type: "canActAs", party: "Alice" },
+      ],
+    }),
+    createMultiStream: vi.fn().mockResolvedValue(mockMultiStream),
+    createMultiInterfaceStream: vi.fn().mockResolvedValue(mockInterfaceMultiStream),
+  };
+
+  // Use a regular function so it can be called with `new`
+  const MockLedger = vi.fn(function (this: any) {
+    Object.assign(this, mockLedgerInstance);
+  });
+
+  return { mockMultiStream, mockInterfaceMultiStream, mockLedgerInstance, MockLedger };
+});
+
+vi.mock("@c7-digital/ledger", () => ({
+  Ledger: MockLedger,
+}));
+
+// Must import AFTER vi.mock
+import { ActiveContractsService } from "../../acs/activeContractsService.js";
+
+describe("ActiveContractsService", () => {
+  const versionedRegistry = vi.fn() as any;
+  let logger: ReturnType<typeof createMockLogger>;
+  let acs: ActiveContractsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-wire default return values after clearAllMocks
+    mockLedgerInstance.getTokenUserInfo.mockResolvedValue({
+      rights: [
+        { type: "canReadAs", party: "Alice" },
+        { type: "canActAs", party: "Alice" },
+      ],
+    });
+    mockLedgerInstance.createMultiStream.mockResolvedValue(mockMultiStream);
+    mockLedgerInstance.createMultiInterfaceStream.mockResolvedValue(mockInterfaceMultiStream);
+
+    logger = createMockLogger();
+    acs = new ActiveContractsService({
+      ledgerUrl: "http://localhost:7575",
+      versionedRegistry,
+      logger,
+    });
+  });
+
+  describe("construction", () => {
+    it("creates without logger (uses noOpLogger)", () => {
+      const service = new ActiveContractsService({
+        versionedRegistry,
+      });
+      expect(service.getIsInitialized()).toBe(false);
+    });
+
+    it("accepts ledgerUrl from options", () => {
+      const service = new ActiveContractsService({
+        ledgerUrl: "http://custom:8080",
+        versionedRegistry,
+        logger,
+      });
+      expect(service.getIsInitialized()).toBe(false);
+    });
+
+    it("accepts ledgerUrl via setLedgerUrl", () => {
+      const service = new ActiveContractsService({ versionedRegistry, logger });
+      service.setLedgerUrl("http://late:9090");
+    });
+  });
+
+  describe("registerTemplate", () => {
+    it("returns a tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      const tracker = acs.registerTemplate(template);
+      expect(tracker).toBeDefined();
+      expect(tracker.getContractCount()).toBe(0);
+    });
+
+    it("throws on duplicate registration", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      acs.registerTemplate(template);
+      expect(() => acs.registerTemplate(template)).toThrow("already registered");
+    });
+
+    it("throws after initialization", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+
+      expect(() => acs.registerTemplate(createMockTemplate("pkg:Mod:T2"))).toThrow(
+        "after initialization",
+      );
+    });
+
+    it("accepts relevanceFn", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      const tracker = acs.registerTemplate(template, (p: any) => p.active === true);
+      expect(tracker).toBeDefined();
+    });
+  });
+
+  describe("registerInterface", () => {
+    it("returns a tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      const tracker = acs.registerInterface(iface);
+      expect(tracker).toBeDefined();
+      expect(tracker.getInterfaceCount()).toBe(0);
+    });
+
+    it("throws on duplicate registration", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      acs.registerInterface(iface);
+      expect(() => acs.registerInterface(iface)).toThrow("already registered");
+    });
+
+    it("throws after initialization", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+
+      expect(() => acs.registerInterface(createMockInterfaceCompanion("pkg:Mod:I1"))).toThrow(
+        "after initialization",
+      );
+    });
+  });
+
+  describe("getTracker / getInterfaceTracker", () => {
+    it("returns registered template tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      const registered = acs.registerTemplate(template);
+      expect(acs.getTracker(template)).toBe(registered);
+    });
+
+    it("throws for unregistered template", () => {
+      const template = createMockTemplate("pkg:Mod:Unknown");
+      expect(() => acs.getTracker(template)).toThrow("not registered");
+    });
+
+    it("returns registered interface tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      const registered = acs.registerInterface(iface);
+      expect(acs.getInterfaceTracker(iface)).toBe(registered);
+    });
+
+    it("throws for unregistered interface", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:Unknown");
+      expect(() => acs.getInterfaceTracker(iface)).toThrow("not registered");
+    });
+  });
+
+  describe("initWithToken", () => {
+    it("creates a Ledger with correct options", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("my-token");
+
+      expect(MockLedger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: "my-token",
+          httpBaseUrl: "http://localhost:7575",
+          validation: "logErrors",
+          versionedRegistry,
+        }),
+      );
+    });
+
+    it("strips trailing slash from ledgerUrl", async () => {
+      const service = new ActiveContractsService({
+        ledgerUrl: "http://localhost:7575/",
+        versionedRegistry,
+        logger,
+      });
+      service.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await service.initWithToken("token");
+
+      expect(MockLedger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpBaseUrl: "http://localhost:7575",
+        }),
+      );
+    });
+
+    it("fetches user info", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+
+      expect(mockLedgerInstance.getTokenUserInfo).toHaveBeenCalled();
+    });
+
+    it("starts MultiStream", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+
+      expect(mockLedgerInstance.createMultiStream).toHaveBeenCalled();
+      expect(mockMultiStream.start).toHaveBeenCalled();
+    });
+
+    it("throws without ledgerUrl", async () => {
+      const service = new ActiveContractsService({ versionedRegistry, logger });
+      await expect(service.initWithToken("token")).rejects.toThrow(
+        "Ledger URL must be set before initializing",
+      );
+    });
+
+    it("sets isInitialized to true", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      expect(acs.getIsInitialized()).toBe(false);
+      await acs.initWithToken("token");
+      expect(acs.getIsInitialized()).toBe(true);
+    });
+
+    it("cleans up on re-init", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token1");
+
+      await acs.initWithToken("token2");
+      // First multiStream should have been closed during cleanup
+      expect(mockMultiStream.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("InterfaceMultiStream", () => {
+    it("initializes when interfaces are registered", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      acs.registerInterface(createMockInterfaceCompanion("pkg:Mod:I1"));
+      await acs.initWithToken("token");
+
+      expect(mockLedgerInstance.createMultiInterfaceStream).toHaveBeenCalled();
+      expect(mockInterfaceMultiStream.start).toHaveBeenCalled();
+    });
+
+    it("skips when no interfaces are registered", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+
+      expect(mockLedgerInstance.createMultiInterfaceStream).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("convenience methods", () => {
+    it("getPayload delegates to tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      acs.registerTemplate(template);
+      expect(acs.getPayload(template, "cid-x" as any)).toBeUndefined();
+    });
+
+    it("getAllPayloads delegates to tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      acs.registerTemplate(template);
+      const result = acs.getAllPayloads(template);
+      expect(result).toBeInstanceOf(Map);
+      expect(result!.size).toBe(0);
+    });
+
+    it("getContractCount delegates to tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      acs.registerTemplate(template);
+      expect(acs.getContractCount(template)).toBe(0);
+    });
+
+    it("getAllCreateEvents delegates to tracker", () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      acs.registerTemplate(template);
+      const result = acs.getAllCreateEvents(template);
+      expect(result).toBeInstanceOf(Map);
+    });
+
+    it("getRegisteredContractTypes returns template IDs", () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T2"));
+      const types = acs.getRegisteredContractTypes();
+      expect(types).toContain("pkg:Mod:T1");
+      expect(types).toContain("pkg:Mod:T2");
+    });
+
+    it("getInterfaceView delegates to tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      acs.registerInterface(iface);
+      expect(acs.getInterfaceView(iface, "cid-x" as any)).toBeUndefined();
+    });
+
+    it("getAllInterfaceViews delegates to tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      acs.registerInterface(iface);
+      const result = acs.getAllInterfaceViews(iface);
+      expect(result).toBeInstanceOf(Map);
+    });
+
+    it("getInterfaceCount delegates to tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      acs.registerInterface(iface);
+      expect(acs.getInterfaceCount(iface)).toBe(0);
+    });
+
+    it("getAllInterfaceEvents delegates to tracker", () => {
+      const iface = createMockInterfaceCompanion("pkg:Mod:I1");
+      acs.registerInterface(iface);
+      const result = acs.getAllInterfaceEvents(iface);
+      expect(result).toBeInstanceOf(Map);
+    });
+
+    it("getRegisteredInterfaceTypes returns interface IDs", () => {
+      acs.registerInterface(createMockInterfaceCompanion("pkg:Mod:I1"));
+      acs.registerInterface(createMockInterfaceCompanion("pkg:Mod:I2"));
+      const types = acs.getRegisteredInterfaceTypes();
+      expect(types).toContain("pkg:Mod:I1");
+      expect(types).toContain("pkg:Mod:I2");
+    });
+  });
+
+  describe("stream GC management", () => {
+    it("addStreamReference / removeStreamReference", () => {
+      const mockStream = { close: vi.fn() } as any;
+      acs.addStreamReference(mockStream);
+      acs.removeStreamReference(mockStream);
+      expect(logger.debug).toHaveBeenCalled();
+    });
+
+    it("removeStreamReference is no-op for unknown stream", () => {
+      const mockStream = { close: vi.fn() } as any;
+      acs.removeStreamReference(mockStream);
+    });
+  });
+
+  describe("cleanupStream", () => {
+    it("closes all streams and resets state", async () => {
+      acs.registerTemplate(createMockTemplate("pkg:Mod:T1"));
+      await acs.initWithToken("token");
+      expect(acs.getIsInitialized()).toBe(true);
+
+      await acs.cleanupStream();
+      expect(acs.getIsInitialized()).toBe(false);
+      expect(acs.getLedger()).toBeUndefined();
+    });
+
+    it("closes individually tracked streams", async () => {
+      const mockStream = { close: vi.fn() } as any;
+      acs.addStreamReference(mockStream);
+
+      await acs.cleanupStream();
+      expect(mockStream.close).toHaveBeenCalled();
+    });
+
+    it("preserves tracker contract data", async () => {
+      const template = createMockTemplate("pkg:Mod:T1");
+      const tracker = acs.registerTemplate(template);
+      const { createMockCreateEvent } = await import("../helpers/mocks.js");
+      await tracker.handleContractCreated(
+        createMockCreateEvent("cid-1", { test: true }),
+      );
+
+      await acs.cleanupStream();
+
+      expect(tracker.getContractCount()).toBe(1);
+    });
+
+    it("handles cleanup when streams throw on close", async () => {
+      const badStream = {
+        close: vi.fn().mockImplementation(() => {
+          throw new Error("close failed");
+        }),
+      } as any;
+      acs.addStreamReference(badStream);
+
+      await expect(acs.cleanupStream()).resolves.not.toThrow();
+    });
+  });
+});

--- a/server/src/__tests__/acs/interfaceTracker.test.ts
+++ b/server/src/__tests__/acs/interfaceTracker.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { InterfaceTracker } from "../../acs/interfaceTracker.js";
+import {
+  createMockLogger,
+  createMockInterfaceCompanion,
+  createMockInterfaceEvent,
+} from "../helpers/mocks.js";
+import type { ContractId } from "@daml/types";
+
+interface TestView {
+  name: string;
+  amount: number;
+}
+
+describe("InterfaceTracker", () => {
+  const interfaceId = "pkg:Mod:TestInterface";
+  let tracker: InterfaceTracker<TestView>;
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    tracker = new InterfaceTracker(createMockInterfaceCompanion(interfaceId), logger);
+  });
+
+  describe("handleInterfaceViewed", () => {
+    it("adds an interface to the map", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+
+      expect(tracker.getInterfaceCount()).toBe(1);
+      expect(tracker.getView(event.contractId)).toEqual({ name: "Alice", amount: 100 });
+    });
+
+    it("stores the Interface event", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+
+      expect(tracker.getInterfaceEvent(event.contractId)).toBe(event);
+    });
+
+    it("records firstSeenAt", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+
+      const meta = tracker.getAllInterfacesWithMeta();
+      expect(meta).toHaveLength(1);
+      expect(meta[0]!.firstSeenAt).toBeDefined();
+      expect(new Date(meta[0]!.firstSeenAt).getTime()).not.toBeNaN();
+    });
+
+    it("does not overwrite firstSeenAt on duplicate", async () => {
+      const event1 = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event1);
+      const originalFirstSeenAt = tracker.getAllInterfacesWithMeta()[0]!.firstSeenAt;
+
+      const event2 = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 200 });
+      await tracker.handleInterfaceViewed(event2);
+      expect(tracker.getAllInterfacesWithMeta()[0]!.firstSeenAt).toBe(originalFirstSeenAt);
+    });
+
+    it("fires onViewed callbacks", async () => {
+      const callback = vi.fn();
+      tracker.onViewed("test-cb", callback);
+
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+
+      expect(callback).toHaveBeenCalledWith(event.contractId, event.interfaceView, event);
+    });
+
+    it("catches callback errors without throwing", async () => {
+      tracker.onViewed("bad-cb", () => {
+        throw new Error("callback failed");
+      });
+
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await expect(tracker.handleInterfaceViewed(event)).resolves.not.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("increments count for multiple interfaces", async () => {
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-1", { name: "A", amount: 1 }));
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-2", { name: "B", amount: 2 }));
+
+      expect(tracker.getInterfaceCount()).toBe(2);
+    });
+  });
+
+  describe("relevanceFn", () => {
+    it("filters irrelevant interfaces", async () => {
+      const relevantTracker = new InterfaceTracker(
+        createMockInterfaceCompanion(interfaceId),
+        logger,
+        (v: TestView) => v.name === "Alice",
+      );
+
+      await relevantTracker.handleInterfaceViewed(
+        createMockInterfaceEvent("cid-1", { name: "Bob", amount: 10 }),
+      );
+
+      expect(relevantTracker.getInterfaceCount()).toBe(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("accepts relevant interfaces", async () => {
+      const relevantTracker = new InterfaceTracker(
+        createMockInterfaceCompanion(interfaceId),
+        logger,
+        (v: TestView) => v.name === "Alice",
+      );
+
+      await relevantTracker.handleInterfaceViewed(
+        createMockInterfaceEvent("cid-1", { name: "Alice", amount: 10 }),
+      );
+
+      expect(relevantTracker.getInterfaceCount()).toBe(1);
+    });
+
+    it("skips callbacks for filtered interfaces", async () => {
+      const relevantTracker = new InterfaceTracker(
+        createMockInterfaceCompanion(interfaceId),
+        logger,
+        (v: TestView) => v.name === "Alice",
+      );
+      const callback = vi.fn();
+      relevantTracker.onViewed("cb", callback);
+
+      await relevantTracker.handleInterfaceViewed(
+        createMockInterfaceEvent("cid-1", { name: "Bob", amount: 10 }),
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleInterfaceArchived", () => {
+    it("removes interface from the map", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+      expect(tracker.getInterfaceCount()).toBe(1);
+
+      await tracker.handleInterfaceArchived(event.contractId);
+      expect(tracker.getInterfaceCount()).toBe(0);
+      expect(tracker.getView(event.contractId)).toBeUndefined();
+    });
+
+    it("fires onArchived callbacks with view", async () => {
+      const callback = vi.fn();
+      tracker.onArchived("archive-cb", callback);
+
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+      await tracker.handleInterfaceArchived(event.contractId);
+
+      expect(callback).toHaveBeenCalledWith(event.contractId, { name: "Alice", amount: 100 });
+    });
+
+    it("catches callback errors", async () => {
+      tracker.onArchived("bad-cb", () => {
+        throw new Error("archive callback failed");
+      });
+
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+      await expect(tracker.handleInterfaceArchived(event.contractId)).resolves.not.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("is a no-op for unknown contractId", async () => {
+      const callback = vi.fn();
+      tracker.onArchived("cb", callback);
+
+      await tracker.handleInterfaceArchived("unknown-id" as unknown as ContractId<TestView>);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("removes firstSeenAt entry", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "Alice", amount: 100 });
+      await tracker.handleInterfaceViewed(event);
+      await tracker.handleInterfaceArchived(event.contractId);
+
+      expect(tracker.getAllInterfacesWithMeta()).toHaveLength(0);
+    });
+  });
+
+  describe("getAllInterfaces / getAllInterfaceEvents / getAllInterfacesWithMeta", () => {
+    it("getAllInterfaces returns Map of contractId → view", async () => {
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-1", { name: "A", amount: 1 }));
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-2", { name: "B", amount: 2 }));
+
+      const interfaces = tracker.getAllInterfaces();
+      expect(interfaces.size).toBe(2);
+      expect(interfaces.get("cid-1" as unknown as ContractId<TestView>)).toEqual({ name: "A", amount: 1 });
+    });
+
+    it("getAllInterfaceEvents returns Map of contractId → Interface event", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "A", amount: 1 });
+      await tracker.handleInterfaceViewed(event);
+
+      const events = tracker.getAllInterfaceEvents();
+      expect(events.size).toBe(1);
+      expect(events.get(event.contractId)).toBe(event);
+    });
+
+    it("getAllInterfacesWithMeta returns array with firstSeenAt", async () => {
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-1", { name: "A", amount: 1 }));
+
+      const meta = tracker.getAllInterfacesWithMeta();
+      expect(meta).toHaveLength(1);
+      expect(meta[0]).toHaveProperty("contractId");
+      expect(meta[0]).toHaveProperty("view");
+      expect(meta[0]).toHaveProperty("firstSeenAt");
+    });
+  });
+
+  describe("hasInterface", () => {
+    it("returns true for existing interface", async () => {
+      const event = createMockInterfaceEvent("cid-1", { name: "A", amount: 1 });
+      await tracker.handleInterfaceViewed(event);
+      expect(tracker.hasInterface(event.contractId)).toBe(true);
+    });
+
+    it("returns false for non-existing interface", () => {
+      expect(tracker.hasInterface("cid-x" as unknown as ContractId<TestView>)).toBe(false);
+    });
+  });
+
+  describe("getInterfaceId", () => {
+    it("returns the configured interfaceId", () => {
+      expect(tracker.getInterfaceId()).toBe(interfaceId);
+    });
+  });
+
+  describe("callbacks", () => {
+    it("throws on duplicate viewed callback key", () => {
+      tracker.onViewed("dup", vi.fn());
+      expect(() => tracker.onViewed("dup", vi.fn())).toThrow("Callback with key dup already exists");
+    });
+
+    it("throws on duplicate archived callback key", () => {
+      tracker.onArchived("dup", vi.fn());
+      expect(() => tracker.onArchived("dup", vi.fn())).toThrow("Callback with key dup already exists");
+    });
+
+    it("removes viewed callback", async () => {
+      const cb = vi.fn();
+      tracker.onViewed("key1", cb);
+      tracker.removeViewedCallback("key1");
+
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-1", { name: "A", amount: 1 }));
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("removes archived callback", async () => {
+      const cb = vi.fn();
+      tracker.onArchived("key1", cb);
+      tracker.removeArchivedCallback("key1");
+
+      const event = createMockInterfaceEvent("cid-1", { name: "A", amount: 1 });
+      await tracker.handleInterfaceViewed(event);
+      await tracker.handleInterfaceArchived(event.contractId);
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("clears interfaces and callbacks", async () => {
+      tracker.onViewed("cb", vi.fn());
+      tracker.onArchived("cb", vi.fn());
+      await tracker.handleInterfaceViewed(createMockInterfaceEvent("cid-1", { name: "A", amount: 1 }));
+
+      tracker.cleanup();
+
+      expect(tracker.getInterfaceCount()).toBe(0);
+      expect(() => tracker.onViewed("cb", vi.fn())).not.toThrow();
+      expect(() => tracker.onArchived("cb", vi.fn())).not.toThrow();
+    });
+  });
+});

--- a/server/src/__tests__/acs/registries.test.ts
+++ b/server/src/__tests__/acs/registries.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  TypeSafeTrackerRegistry,
+  TypeSafeInterfaceTrackerRegistry,
+} from "../../acs/registries.js";
+import type { PackageIdString } from "@c7-digital/ledger";
+
+describe("TypeSafeTrackerRegistry", () => {
+  const id1 = "pkg1:Mod:Template1" as PackageIdString;
+  const id2 = "pkg2:Mod:Template2" as PackageIdString;
+
+  it("starts empty", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    expect(registry.length()).toBe(0);
+    expect(registry.has(id1)).toBe(false);
+  });
+
+  it("stores and retrieves a tracker", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    const tracker = { mock: true } as any;
+    registry.set(id1, tracker);
+    expect(registry.get(id1)).toBe(tracker);
+  });
+
+  it("returns undefined for missing key", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    expect(registry.get(id1)).toBeUndefined();
+  });
+
+  it("has() returns true for set keys", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    registry.set(id1, {} as any);
+    expect(registry.has(id1)).toBe(true);
+    expect(registry.has(id2)).toBe(false);
+  });
+
+  it("reports correct length", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    registry.set(id1, {} as any);
+    registry.set(id2, {} as any);
+    expect(registry.length()).toBe(2);
+  });
+
+  it("iterates values", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    const t1 = { id: 1 } as any;
+    const t2 = { id: 2 } as any;
+    registry.set(id1, t1);
+    registry.set(id2, t2);
+    const values = Array.from(registry.values());
+    expect(values).toContain(t1);
+    expect(values).toContain(t2);
+  });
+
+  it("iterates keys", () => {
+    const registry = new TypeSafeTrackerRegistry();
+    registry.set(id1, {} as any);
+    registry.set(id2, {} as any);
+    const keys = Array.from(registry.keys());
+    expect(keys).toContain(id1);
+    expect(keys).toContain(id2);
+  });
+});
+
+describe("TypeSafeInterfaceTrackerRegistry", () => {
+  const id1 = "pkg1:Mod:Iface1" as PackageIdString;
+  const id2 = "pkg2:Mod:Iface2" as PackageIdString;
+
+  it("starts empty", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    expect(registry.length()).toBe(0);
+    expect(registry.has(id1)).toBe(false);
+  });
+
+  it("stores and retrieves a tracker", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    const tracker = { mock: true } as any;
+    registry.set(id1, tracker);
+    expect(registry.get(id1)).toBe(tracker);
+  });
+
+  it("returns undefined for missing key", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    expect(registry.get(id1)).toBeUndefined();
+  });
+
+  it("has() returns true for set keys", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    registry.set(id1, {} as any);
+    expect(registry.has(id1)).toBe(true);
+    expect(registry.has(id2)).toBe(false);
+  });
+
+  it("reports correct length", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    registry.set(id1, {} as any);
+    registry.set(id2, {} as any);
+    expect(registry.length()).toBe(2);
+  });
+
+  it("iterates values", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    const t1 = { id: 1 } as any;
+    const t2 = { id: 2 } as any;
+    registry.set(id1, t1);
+    registry.set(id2, t2);
+    const values = Array.from(registry.values());
+    expect(values).toContain(t1);
+    expect(values).toContain(t2);
+  });
+
+  it("iterates keys", () => {
+    const registry = new TypeSafeInterfaceTrackerRegistry();
+    registry.set(id1, {} as any);
+    registry.set(id2, {} as any);
+    const keys = Array.from(registry.keys());
+    expect(keys).toContain(id1);
+    expect(keys).toContain(id2);
+  });
+});

--- a/server/src/__tests__/acs/templateTracker.test.ts
+++ b/server/src/__tests__/acs/templateTracker.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TemplateTracker } from "../../acs/templateTracker.js";
+import {
+  createMockLogger,
+  createMockTemplate,
+  createMockCreateEvent,
+} from "../helpers/mocks.js";
+import type { ContractId } from "@daml/types";
+
+interface TestPayload {
+  owner: string;
+  value: number;
+}
+
+describe("TemplateTracker", () => {
+  const templateId = "pkg:Mod:TestTemplate";
+  let tracker: TemplateTracker<TestPayload>;
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    tracker = new TemplateTracker(createMockTemplate(templateId), logger);
+  });
+
+  describe("handleContractCreated", () => {
+    it("adds a contract to the map", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+
+      expect(tracker.getContractCount()).toBe(1);
+      expect(tracker.getPayload(event.contractId)).toEqual({ owner: "Alice", value: 10 });
+    });
+
+    it("stores the CreateEvent", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+
+      expect(tracker.getCreateEvent(event.contractId)).toBe(event);
+    });
+
+    it("records firstSeenAt", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+
+      const meta = tracker.getAllContractsWithMeta();
+      expect(meta).toHaveLength(1);
+      expect(meta[0]!.firstSeenAt).toBeDefined();
+      expect(new Date(meta[0]!.firstSeenAt).getTime()).not.toBeNaN();
+    });
+
+    it("does not overwrite firstSeenAt on duplicate", async () => {
+      const event1 = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event1);
+      const firstMeta = tracker.getAllContractsWithMeta();
+      const originalFirstSeenAt = firstMeta[0]!.firstSeenAt;
+
+      // Re-create same contractId with different payload
+      const event2 = createMockCreateEvent("cid-1", { owner: "Alice", value: 20 });
+      await tracker.handleContractCreated(event2);
+      const secondMeta = tracker.getAllContractsWithMeta();
+
+      expect(secondMeta[0]!.firstSeenAt).toBe(originalFirstSeenAt);
+    });
+
+    it("fires onCreated callbacks", async () => {
+      const callback = vi.fn();
+      tracker.onCreated("test-cb", callback);
+
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+
+      expect(callback).toHaveBeenCalledWith(event.contractId, event.payload, event);
+    });
+
+    it("catches callback errors without throwing", async () => {
+      tracker.onCreated("bad-cb", () => {
+        throw new Error("callback failed");
+      });
+
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await expect(tracker.handleContractCreated(event)).resolves.not.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("increments contract count for multiple contracts", async () => {
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+      await tracker.handleContractCreated(createMockCreateEvent("cid-2", { owner: "B", value: 2 }));
+
+      expect(tracker.getContractCount()).toBe(2);
+    });
+  });
+
+  describe("relevanceFn", () => {
+    it("filters irrelevant contracts", async () => {
+      const relevantTracker = new TemplateTracker(
+        createMockTemplate(templateId),
+        logger,
+        (p: TestPayload) => p.owner === "Alice",
+      );
+
+      const event = createMockCreateEvent("cid-1", { owner: "Bob", value: 10 });
+      await relevantTracker.handleContractCreated(event);
+
+      expect(relevantTracker.getContractCount()).toBe(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("accepts relevant contracts", async () => {
+      const relevantTracker = new TemplateTracker(
+        createMockTemplate(templateId),
+        logger,
+        (p: TestPayload) => p.owner === "Alice",
+      );
+
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await relevantTracker.handleContractCreated(event);
+
+      expect(relevantTracker.getContractCount()).toBe(1);
+    });
+
+    it("skips callbacks for filtered contracts", async () => {
+      const relevantTracker = new TemplateTracker(
+        createMockTemplate(templateId),
+        logger,
+        (p: TestPayload) => p.owner === "Alice",
+      );
+      const callback = vi.fn();
+      relevantTracker.onCreated("cb", callback);
+
+      await relevantTracker.handleContractCreated(
+        createMockCreateEvent("cid-1", { owner: "Bob", value: 10 }),
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleContractArchived", () => {
+    it("removes contract from the map", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+      expect(tracker.getContractCount()).toBe(1);
+
+      await tracker.handleContractArchived(event.contractId);
+      expect(tracker.getContractCount()).toBe(0);
+      expect(tracker.getPayload(event.contractId)).toBeUndefined();
+    });
+
+    it("fires onArchived callbacks with payload", async () => {
+      const callback = vi.fn();
+      tracker.onArchived("archive-cb", callback);
+
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+      await tracker.handleContractArchived(event.contractId);
+
+      expect(callback).toHaveBeenCalledWith(event.contractId, { owner: "Alice", value: 10 });
+    });
+
+    it("catches callback errors", async () => {
+      tracker.onArchived("bad-archive-cb", () => {
+        throw new Error("archive callback failed");
+      });
+
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+      await expect(tracker.handleContractArchived(event.contractId)).resolves.not.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("is a no-op for unknown contractId", async () => {
+      const callback = vi.fn();
+      tracker.onArchived("cb", callback);
+
+      await tracker.handleContractArchived("unknown-id" as unknown as ContractId<TestPayload>);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("removes firstSeenAt entry", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "Alice", value: 10 });
+      await tracker.handleContractCreated(event);
+      await tracker.handleContractArchived(event.contractId);
+
+      expect(tracker.getAllContractsWithMeta()).toHaveLength(0);
+    });
+  });
+
+  describe("getAllContracts / getAllCreateEvents / getAllContractsWithMeta", () => {
+    it("getAllContracts returns Map of contractId → payload", async () => {
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+      await tracker.handleContractCreated(createMockCreateEvent("cid-2", { owner: "B", value: 2 }));
+
+      const contracts = tracker.getAllContracts();
+      expect(contracts.size).toBe(2);
+      expect(contracts.get("cid-1" as unknown as ContractId<TestPayload>)).toEqual({ owner: "A", value: 1 });
+    });
+
+    it("getAllCreateEvents returns Map of contractId → CreateEvent", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "A", value: 1 });
+      await tracker.handleContractCreated(event);
+
+      const events = tracker.getAllCreateEvents();
+      expect(events.size).toBe(1);
+      expect(events.get(event.contractId)).toBe(event);
+    });
+
+    it("getAllContractsWithMeta returns array with firstSeenAt", async () => {
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+
+      const meta = tracker.getAllContractsWithMeta();
+      expect(meta).toHaveLength(1);
+      expect(meta[0]).toHaveProperty("contractId");
+      expect(meta[0]).toHaveProperty("payload");
+      expect(meta[0]).toHaveProperty("firstSeenAt");
+    });
+  });
+
+  describe("hasContract", () => {
+    it("returns true for existing contract", async () => {
+      const event = createMockCreateEvent("cid-1", { owner: "A", value: 1 });
+      await tracker.handleContractCreated(event);
+      expect(tracker.hasContract(event.contractId)).toBe(true);
+    });
+
+    it("returns false for non-existing contract", () => {
+      expect(tracker.hasContract("cid-x" as unknown as ContractId<TestPayload>)).toBe(false);
+    });
+  });
+
+  describe("getTemplateId", () => {
+    it("returns the configured templateId", () => {
+      expect(tracker.getTemplateId()).toBe(templateId);
+    });
+  });
+
+  describe("callbacks", () => {
+    it("registers and fires created callback", async () => {
+      const cb = vi.fn();
+      tracker.onCreated("key1", cb);
+
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it("registers and fires archived callback", async () => {
+      const cb = vi.fn();
+      tracker.onArchived("key1", cb);
+
+      const event = createMockCreateEvent("cid-1", { owner: "A", value: 1 });
+      await tracker.handleContractCreated(event);
+      await tracker.handleContractArchived(event.contractId);
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it("throws on duplicate created callback key", () => {
+      tracker.onCreated("dup", vi.fn());
+      expect(() => tracker.onCreated("dup", vi.fn())).toThrow("Callback with key dup already exists");
+    });
+
+    it("throws on duplicate archived callback key", () => {
+      tracker.onArchived("dup", vi.fn());
+      expect(() => tracker.onArchived("dup", vi.fn())).toThrow("Callback with key dup already exists");
+    });
+
+    it("removes created callback", async () => {
+      const cb = vi.fn();
+      tracker.onCreated("key1", cb);
+      tracker.removeCreatedCallback("key1");
+
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("removes archived callback", async () => {
+      const cb = vi.fn();
+      tracker.onArchived("key1", cb);
+      tracker.removeArchivedCallback("key1");
+
+      const event = createMockCreateEvent("cid-1", { owner: "A", value: 1 });
+      await tracker.handleContractCreated(event);
+      await tracker.handleContractArchived(event.contractId);
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("clears contracts and callbacks", async () => {
+      tracker.onCreated("cb", vi.fn());
+      tracker.onArchived("cb", vi.fn());
+      await tracker.handleContractCreated(createMockCreateEvent("cid-1", { owner: "A", value: 1 }));
+
+      tracker.cleanup();
+
+      expect(tracker.getContractCount()).toBe(0);
+      // After cleanup, registering with same key should not throw
+      expect(() => tracker.onCreated("cb", vi.fn())).not.toThrow();
+      expect(() => tracker.onArchived("cb", vi.fn())).not.toThrow();
+    });
+  });
+});

--- a/server/src/__tests__/auth/apiAuth.test.ts
+++ b/server/src/__tests__/auth/apiAuth.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseAuthPayload,
+  encodeAuthPayload,
+  decodeAuthPayload,
+  createAdminAuth,
+  createContractAuth,
+  isAdminAuth,
+  isContractAuth,
+  type AuthPayload,
+  type AdminAuthPayload,
+  type ContractAuthPayload,
+} from "../../auth/apiAuth.js";
+
+describe("parseAuthPayload", () => {
+  it("parses a valid admin payload", () => {
+    const result = parseAuthPayload({ type: "admin", apiKey: "my-key" });
+    expect(result).toEqual({
+      success: true,
+      data: { type: "admin", apiKey: "my-key" },
+    });
+  });
+
+  it("parses a valid contract payload", () => {
+    const result = parseAuthPayload({
+      type: "contract",
+      contractId: "cid-123",
+      party: "Alice",
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { type: "contract", contractId: "cid-123", party: "Alice" },
+    });
+  });
+
+  it("rejects empty apiKey", () => {
+    const result = parseAuthPayload({ type: "admin", apiKey: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("API key cannot be empty");
+    }
+  });
+
+  it("rejects empty contractId", () => {
+    const result = parseAuthPayload({
+      type: "contract",
+      contractId: "",
+      party: "Alice",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Contract ID cannot be empty");
+    }
+  });
+
+  it("rejects empty party", () => {
+    const result = parseAuthPayload({
+      type: "contract",
+      contractId: "cid-123",
+      party: "",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Party cannot be empty");
+    }
+  });
+
+  it("rejects extra fields (strict mode)", () => {
+    const result = parseAuthPayload({
+      type: "admin",
+      apiKey: "key",
+      extra: "field",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects null", () => {
+    const result = parseAuthPayload(null);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    const result = parseAuthPayload(undefined);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown type", () => {
+    const result = parseAuthPayload({ type: "unknown", data: "value" });
+    expect(result.success).toBe(false);
+  });
+
+  it("returns descriptive error messages", () => {
+    const result = parseAuthPayload({ type: "admin" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Validation failed");
+    }
+  });
+});
+
+describe("encodeAuthPayload / decodeAuthPayload", () => {
+  it("round-trips an admin payload", () => {
+    const payload: AdminAuthPayload = { type: "admin", apiKey: "secret-key" };
+    const encoded = encodeAuthPayload(payload);
+    const decoded = decodeAuthPayload(encoded);
+
+    expect(decoded).toEqual({ success: true, data: payload });
+  });
+
+  it("round-trips a contract payload", () => {
+    const payload: ContractAuthPayload = {
+      type: "contract",
+      contractId: "cid-abc",
+      party: "Bob",
+    };
+    const encoded = encodeAuthPayload(payload);
+    const decoded = decodeAuthPayload(encoded);
+
+    expect(decoded).toEqual({ success: true, data: payload });
+  });
+
+  it("returns failure for invalid base64", () => {
+    const result = decodeAuthPayload("!!!not-base64!!!");
+    expect(result.success).toBe(false);
+  });
+
+  it("returns failure for valid base64 with invalid JSON", () => {
+    const encoded = Buffer.from("not json", "utf-8").toString("base64");
+    const result = decodeAuthPayload(encoded);
+    expect(result.success).toBe(false);
+  });
+
+  it("returns failure for valid JSON that doesn't match schema", () => {
+    const encoded = Buffer.from(
+      JSON.stringify({ type: "bad", foo: "bar" }),
+      "utf-8"
+    ).toString("base64");
+    const result = decodeAuthPayload(encoded);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createAdminAuth / createContractAuth", () => {
+  it("creates and decodes admin auth", () => {
+    const encoded = createAdminAuth("my-api-key");
+    const decoded = decodeAuthPayload(encoded);
+
+    expect(decoded).toEqual({
+      success: true,
+      data: { type: "admin", apiKey: "my-api-key" },
+    });
+  });
+
+  it("creates and decodes contract auth", () => {
+    const encoded = createContractAuth("cid-xyz", "Charlie");
+    const decoded = decodeAuthPayload(encoded);
+
+    expect(decoded).toEqual({
+      success: true,
+      data: { type: "contract", contractId: "cid-xyz", party: "Charlie" },
+    });
+  });
+
+  it("preserves all values through round-trip", () => {
+    const contractId = "00abcd1234567890abcdef";
+    const party = "party::namespace";
+    const encoded = createContractAuth(contractId, party);
+    const decoded = decodeAuthPayload(encoded);
+
+    expect(decoded.success).toBe(true);
+    if (decoded.success) {
+      expect(decoded.data).toEqual({
+        type: "contract",
+        contractId,
+        party,
+      });
+    }
+  });
+});
+
+describe("isAdminAuth / isContractAuth", () => {
+  it("correctly identifies admin auth", () => {
+    const payload: AuthPayload = { type: "admin", apiKey: "key" };
+    expect(isAdminAuth(payload)).toBe(true);
+    expect(isContractAuth(payload)).toBe(false);
+  });
+
+  it("correctly identifies contract auth", () => {
+    const payload: AuthPayload = {
+      type: "contract",
+      contractId: "cid",
+      party: "Alice",
+    };
+    expect(isAdminAuth(payload)).toBe(false);
+    expect(isContractAuth(payload)).toBe(true);
+  });
+
+  it("narrows type correctly for admin", () => {
+    const payload: AuthPayload = { type: "admin", apiKey: "key" };
+    if (isAdminAuth(payload)) {
+      // TypeScript should allow accessing apiKey here
+      expect(payload.apiKey).toBe("key");
+    }
+  });
+
+  it("narrows type correctly for contract", () => {
+    const payload: AuthPayload = {
+      type: "contract",
+      contractId: "cid",
+      party: "Alice",
+    };
+    if (isContractAuth(payload)) {
+      // TypeScript should allow accessing contractId and party here
+      expect(payload.contractId).toBe("cid");
+      expect(payload.party).toBe("Alice");
+    }
+  });
+});

--- a/server/src/__tests__/auth/helpers.test.ts
+++ b/server/src/__tests__/auth/helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { getAuthPayloadFromRequest } from "../../auth/helpers.js";
+import { createAdminAuth, createContractAuth } from "../../auth/apiAuth.js";
+
+describe("getAuthPayloadFromRequest", () => {
+  it("extracts a valid admin Bearer token", () => {
+    const token = createAdminAuth("my-key");
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result).toEqual({
+      success: true,
+      data: { type: "admin", apiKey: "my-key" },
+    });
+  });
+
+  it("extracts a valid contract Bearer token", () => {
+    const token = createContractAuth("cid-123", "Alice");
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result).toEqual({
+      success: true,
+      data: { type: "contract", contractId: "cid-123", party: "Alice" },
+    });
+  });
+
+  it("fails for missing authorization header", () => {
+    const req = { headers: {} };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Missing authorization header");
+    }
+  });
+
+  it("fails for undefined authorization header", () => {
+    const req = { headers: { authorization: undefined } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails for wrong prefix (Basic instead of Bearer)", () => {
+    const token = createAdminAuth("key");
+    const req = { headers: { authorization: `Basic ${token}` } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Missing authorization header");
+    }
+  });
+
+  it("fails when no space after 'Bearer'", () => {
+    const req = { headers: { authorization: "Bearertoken" } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails for invalid base64 payload", () => {
+    const req = { headers: { authorization: "Bearer !!!invalid!!!" } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("fails for valid base64 with invalid payload schema", () => {
+    const encoded = Buffer.from(
+      JSON.stringify({ type: "bad" }),
+      "utf-8"
+    ).toString("base64");
+    const req = { headers: { authorization: `Bearer ${encoded}` } };
+    const result = getAuthPayloadFromRequest(req);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/src/__tests__/helpers/mocks.ts
+++ b/server/src/__tests__/helpers/mocks.ts
@@ -1,0 +1,74 @@
+import { vi } from "vitest";
+import type { AcsLogger } from "../../acs/types.js";
+import type { CreateEvent, Interface, PackageIdString } from "@c7-digital/ledger";
+import type { ContractId, Template, InterfaceCompanion } from "@daml/types";
+
+/**
+ * Creates a mock AcsLogger where all methods are vi.fn() spies.
+ */
+export function createMockLogger(): AcsLogger & {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+/**
+ * Creates a minimal Template companion stub for testing.
+ */
+export function createMockTemplate(templateId: string): Template<any, any, PackageIdString> {
+  return {
+    templateId: templateId as PackageIdString,
+    keyDecoder: { decoder: {} as any, type: () => ({}) },
+    decoder: { decoder: {} as any, type: () => ({}) },
+    Archive: {} as any,
+    // Template requires these fields
+  } as unknown as Template<any, any, PackageIdString>;
+}
+
+/**
+ * Creates a minimal InterfaceCompanion stub for testing.
+ */
+export function createMockInterfaceCompanion(interfaceId: string): InterfaceCompanion<any, any, PackageIdString> {
+  return {
+    templateId: interfaceId as PackageIdString,
+    decoder: { decoder: {} as any, type: () => ({}) },
+  } as unknown as InterfaceCompanion<any, any, PackageIdString>;
+}
+
+/**
+ * Creates a mock CreateEvent for template tracker testing.
+ */
+export function createMockCreateEvent<T extends object>(
+  contractId: string,
+  payload: T,
+): CreateEvent<T> {
+  return {
+    contractId: contractId as unknown as ContractId<T>,
+    payload,
+    signatories: [],
+    observers: [],
+    createdAt: new Date().toISOString(),
+  } as unknown as CreateEvent<T>;
+}
+
+/**
+ * Creates a mock Interface event for interface tracker testing.
+ */
+export function createMockInterfaceEvent<I extends object>(
+  contractId: string,
+  view: I,
+): Interface<I> {
+  return {
+    contractId: contractId as unknown as ContractId<I>,
+    interfaceView: view,
+    interfaceId: "test-interface-id",
+  } as unknown as Interface<I>;
+}

--- a/server/src/__tests__/identityService.test.ts
+++ b/server/src/__tests__/identityService.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { KeycloakConfig } from "../types.js";
+import type { Logger } from "../logger.js";
+
+function createMockAppLogger(): Logger & {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as any;
+}
+
+// Use vi.hoisted for mock state that needs to be accessible inside vi.mock() factories
+const { mockGrantManager, mockDecodeJwt } = vi.hoisted(() => {
+  const mockGrantManager = {
+    obtainFromClientCredentials: vi.fn(),
+  };
+  const mockDecodeJwt = vi.fn();
+  return { mockGrantManager, mockDecodeJwt };
+});
+
+vi.mock("jose", () => ({
+  decodeJwt: mockDecodeJwt,
+}));
+
+vi.mock("keycloak-connect", () => {
+  return {
+    default: vi.fn(function (this: any) {
+      this.grantManager = mockGrantManager;
+    }),
+  };
+});
+
+// Import after mocks
+import { IdentityService } from "../identityService.js";
+
+describe("IdentityService", () => {
+  const keycloakConfig: KeycloakConfig = {
+    url: "http://keycloak:8080",
+    realm: "test-realm",
+    clientId: "test-client",
+    clientSecret: "test-secret",
+  };
+  let logger: ReturnType<typeof createMockAppLogger>;
+  let service: IdentityService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    logger = createMockAppLogger();
+    service = new IdentityService(keycloakConfig, logger);
+  });
+
+  afterEach(async () => {
+    await service.destroy();
+    vi.useRealTimers();
+  });
+
+  describe("constructor", () => {
+    it("stores config and starts uninitialized", () => {
+      expect(service.isInitialized).toBe(false);
+      expect(service.getToken()).toBeNull();
+      expect(service.getTokenExpiresIn()).toBe(0);
+    });
+  });
+
+  describe("initWithStaticToken", () => {
+    it("sets token", async () => {
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 3600 });
+
+      await service.initWithStaticToken("static-jwt-token");
+      expect(service.getToken()).toBe("static-jwt-token");
+    });
+
+    it("decodes JWT for expiry", async () => {
+      const futureExp = Date.now() / 1000 + 7200;
+      mockDecodeJwt.mockReturnValue({ exp: futureExp });
+
+      await service.initWithStaticToken("static-jwt");
+      expect(mockDecodeJwt).toHaveBeenCalledWith("static-jwt");
+      expect(service.getTokenExpiresIn()).toBeGreaterThan(0);
+    });
+
+    it("sets isInitialized", async () => {
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 3600 });
+
+      await service.initWithStaticToken("token");
+      expect(service.isInitialized).toBe(true);
+    });
+
+    it("notifies registered callbacks", async () => {
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 3600 });
+
+      const callback = vi.fn().mockResolvedValue(undefined);
+      service.onTokenUpdate("test-service", callback);
+
+      await service.initWithStaticToken("new-token");
+      expect(callback).toHaveBeenCalledWith("new-token");
+    });
+
+    it("handles callback errors gracefully", async () => {
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 3600 });
+
+      service.onTokenUpdate("bad-service", async () => {
+        throw new Error("callback failed");
+      });
+
+      await expect(service.initWithStaticToken("token")).resolves.not.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("defaults expiry to 3600 when no exp claim", async () => {
+      mockDecodeJwt.mockReturnValue({}); // no exp
+
+      await service.initWithStaticToken("no-exp-token");
+      expect(service.getTokenExpiresIn()).toBe(3600);
+    });
+  });
+
+  describe("init (Keycloak)", () => {
+    it("creates Keycloak with correct config", async () => {
+      const Keycloak = (await import("keycloak-connect")).default;
+      const newToken = "keycloak-jwt-token";
+
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: newToken },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+
+      expect(Keycloak).toHaveBeenCalledWith(
+        { store: {} },
+        expect.objectContaining({
+          realm: "test-realm",
+          "auth-server-url": "http://keycloak:8080",
+          resource: "test-client",
+        }),
+      );
+    });
+
+    it("fetches token and sets isInitialized", async () => {
+      const newToken = "keycloak-jwt-token";
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: newToken },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+      expect(service.isInitialized).toBe(true);
+      expect(service.getToken()).toBe(newToken);
+    });
+
+    it("throws on failure", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockRejectedValue(
+        new Error("Keycloak unreachable"),
+      );
+
+      // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
+      const assertion = expect(service.init()).rejects.toThrow("Keycloak unreachable");
+      // Advance past retry backoff delays (2s + 4s + 5s cap)
+      await vi.advanceTimersByTimeAsync(15000);
+      await assertion;
+    });
+  });
+
+  describe("getToken / getTokenExpiresIn / getConfig / getStatus", () => {
+    it("returns null token before init", () => {
+      expect(service.getToken()).toBeNull();
+    });
+
+    it("returns 0 tokenExpiresIn before init", () => {
+      expect(service.getTokenExpiresIn()).toBe(0);
+    });
+
+    it("returns config without secret", () => {
+      const config = service.getConfig();
+      expect(config).toEqual({
+        url: "http://keycloak:8080",
+        realm: "test-realm",
+        clientId: "test-client",
+      });
+      expect((config as any).clientSecret).toBeUndefined();
+    });
+
+    it("returns status before init", () => {
+      const status = service.getStatus();
+      expect(status.isInitialized).toBe(false);
+      expect(status.nextRefreshTime).toBeNull();
+      expect(status.hasHeartbeat).toBe(false);
+      expect(status.callbackCount).toBe(0);
+      expect(status.tokenExpiresIn).toBe(0);
+    });
+
+    it("returns correct values after static init", async () => {
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 3600 });
+
+      await service.initWithStaticToken("my-token");
+
+      expect(service.getToken()).toBe("my-token");
+      expect(service.getTokenExpiresIn()).toBeGreaterThan(0);
+      expect(service.getStatus().isInitialized).toBe(true);
+    });
+  });
+
+  describe("token callbacks", () => {
+    it("registers a callback", () => {
+      service.onTokenUpdate("svc1", vi.fn());
+      expect(service.getCallbackCount()).toBe(1);
+    });
+
+    it("removes a callback", () => {
+      service.onTokenUpdate("svc1", vi.fn());
+      const removed = service.removeTokenUpdateCallback("svc1");
+      expect(removed).toBe(true);
+      expect(service.getCallbackCount()).toBe(0);
+    });
+
+    it("removeTokenUpdateCallback returns false for unknown", () => {
+      expect(service.removeTokenUpdateCallback("unknown")).toBe(false);
+    });
+
+    it("reports correct callback count", () => {
+      service.onTokenUpdate("svc1", vi.fn());
+      service.onTokenUpdate("svc2", vi.fn());
+      service.onTokenUpdate("svc3", vi.fn());
+      expect(service.getCallbackCount()).toBe(3);
+    });
+
+    it("callback is called on token change via init", async () => {
+      const callback = vi.fn().mockResolvedValue(undefined);
+      service.onTokenUpdate("svc1", callback);
+
+      const newToken = "new-kc-token";
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: newToken },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+      expect(callback).toHaveBeenCalledWith(newToken);
+    });
+
+    it("callback is NOT called when same token", async () => {
+      const theToken = "same-token";
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: theToken },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+
+      // Register callback after init
+      const callback = vi.fn().mockResolvedValue(undefined);
+      service.onTokenUpdate("late-svc", callback);
+
+      // Advance past the refresh timer (~270s for 300s expiry)
+      // Uses advanceTimersByTimeAsync to avoid infinite loop with heartbeat
+      await vi.advanceTimersByTimeAsync(280000);
+
+      // The callback should NOT have been called because the token didn't change
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("token refresh scheduling", () => {
+    it("schedules refresh before expiry", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: "refresh-token" },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+
+      const status = service.getStatus();
+      expect(status.nextRefreshTime).not.toBeNull();
+      expect(status.nextRefreshTime!).toBeGreaterThan(Date.now());
+    });
+
+    it("rescheduling clears previous timer", async () => {
+      mockGrantManager.obtainFromClientCredentials
+        .mockResolvedValueOnce({
+          access_token: { token: "token-1" },
+          isExpired: () => false,
+          expires_in: "300",
+        })
+        .mockResolvedValue({
+          access_token: { token: "token-2" },
+          isExpired: () => false,
+          expires_in: "600",
+        });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 600 });
+
+      await service.init();
+      const firstRefreshTime = service.getStatus().nextRefreshTime;
+
+      // Advance past the first refresh timer (~270s for 300s expiry)
+      await vi.advanceTimersByTimeAsync(280000);
+
+      const secondRefreshTime = service.getStatus().nextRefreshTime;
+      expect(secondRefreshTime).not.toBe(firstRefreshTime);
+    });
+
+    it("scheduled failure retries in 30s", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValueOnce({
+        access_token: { token: "initial-token" },
+        isExpired: () => false,
+        expires_in: "60",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 60 });
+
+      await service.init();
+
+      // Make subsequent calls fail
+      mockGrantManager.obtainFromClientCredentials.mockRejectedValue(new Error("fail"));
+
+      // Advance past the refresh timer (~30s for 60s expiry) plus retry backoff delays
+      // Refresh fires at ~30s, then 3 retries with delays 2s+4s ≈ 36s total
+      // Stop before the re-scheduled 1s timer cascades further
+      await vi.advanceTimersByTimeAsync(40000);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("will retry in 30 seconds"),
+      );
+    });
+  });
+
+  describe("heartbeat", () => {
+    it("starts 30s interval after init", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: "hb-token" },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+
+      expect(service.getStatus().hasHeartbeat).toBe(true);
+    });
+
+    it("no duplicate intervals on repeated init", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: "hb-token" },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+      expect(service.getStatus().hasHeartbeat).toBe(true);
+    });
+  });
+
+  describe("destroy", () => {
+    it("clears timers and resets state", async () => {
+      mockGrantManager.obtainFromClientCredentials.mockResolvedValue({
+        access_token: { token: "destroy-token" },
+        isExpired: () => false,
+        expires_in: "300",
+      });
+      mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 300 });
+
+      await service.init();
+      expect(service.isInitialized).toBe(true);
+
+      await service.destroy();
+
+      expect(service.isInitialized).toBe(false);
+      expect(service.getToken()).toBe("");
+      expect(service.getTokenExpiresIn()).toBe(0);
+      expect(service.getStatus().hasHeartbeat).toBe(false);
+      expect(service.getStatus().nextRefreshTime).toBeNull();
+    });
+
+    it("is safe to call without init", async () => {
+      await expect(service.destroy()).resolves.not.toThrow();
+    });
+  });
+});

--- a/server/src/__tests__/logger.test.ts
+++ b/server/src/__tests__/logger.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Logger, LedgerLoggerAdapter, limitObjectDepth } from "../logger.js";
+
+describe("limitObjectDepth", () => {
+  it("returns primitives unchanged", () => {
+    expect(limitObjectDepth("hello")).toBe("hello");
+    expect(limitObjectDepth(42)).toBe(42);
+    expect(limitObjectDepth(true)).toBe(true);
+    expect(limitObjectDepth(undefined)).toBe(undefined);
+  });
+
+  it("returns null unchanged", () => {
+    expect(limitObjectDepth(null)).toBe(null);
+  });
+
+  it("returns null at depth boundary", () => {
+    expect(limitObjectDepth(null, 0)).toBe(null);
+  });
+
+  it("truncates objects at maxDepth with key count", () => {
+    const obj = { a: { b: { c: "deep" } } };
+    const result = limitObjectDepth(obj, 2);
+    expect(result).toEqual({ a: { b: "[Object(1 keys)]" } });
+  });
+
+  it("truncates arrays at maxDepth with length", () => {
+    const obj = { a: { b: [1, 2, 3] } };
+    const result = limitObjectDepth(obj, 2);
+    expect(result).toEqual({ a: { b: "[Array(3)]" } });
+  });
+
+  it("returns primitives at maxDepth unchanged", () => {
+    const obj = { a: { b: 42 } };
+    const result = limitObjectDepth(obj, 2);
+    expect(result).toEqual({ a: { b: 42 } });
+  });
+
+  it("uses default depth of 6", () => {
+    // Build a 7-level deep object
+    let obj: any = { value: "leaf" };
+    for (let i = 0; i < 6; i++) {
+      obj = { nested: obj };
+    }
+    const result = limitObjectDepth(obj);
+    // At depth 6, the innermost object should be truncated
+    expect(JSON.stringify(result)).toContain("[Object(");
+  });
+
+  it("handles arrays at non-boundary depths", () => {
+    const arr = [1, "two", { three: 3 }];
+    const result = limitObjectDepth(arr, 3);
+    expect(result).toEqual([1, "two", { three: 3 }]);
+  });
+});
+
+describe("Logger", () => {
+  let logger: Logger;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logger = new Logger();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it("writes JSON to stdout for DEBUG", () => {
+    logger.debug("test message");
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const output = stdoutSpy.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.level).toBe("DEBUG");
+    expect(parsed.message).toBe("test message");
+    expect(parsed["@timestamp"]).toBeDefined();
+  });
+
+  it("writes JSON to stdout for INFO", () => {
+    logger.info("info message");
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.level).toBe("INFO");
+    expect(parsed.message).toBe("info message");
+  });
+
+  it("writes to both stderr and stdout for WARN", () => {
+    logger.warn("warn message");
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const stderrParsed = JSON.parse((stderrSpy.mock.calls[0]![0] as string).trim());
+    expect(stderrParsed.level).toBe("WARN");
+  });
+
+  it("writes to both stderr and stdout for ERROR", () => {
+    logger.error("error message");
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const stderrParsed = JSON.parse((stderrSpy.mock.calls[0]![0] as string).trim());
+    expect(stderrParsed.level).toBe("ERROR");
+  });
+
+  it("does not write to stderr for DEBUG or INFO", () => {
+    logger.debug("debug");
+    logger.info("info");
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("serializes error with name, message, and stack", () => {
+    const err = new Error("something broke");
+    logger.error("failed", err);
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.error).toEqual({
+      name: "Error",
+      message: "something broke",
+      stack: expect.any(String),
+    });
+  });
+
+  it("spreads context into the log entry", () => {
+    logger.info("with context", { requestId: "abc", count: 5 });
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.requestId).toBe("abc");
+    expect(parsed.count).toBe(5);
+  });
+
+  it("merges error and context in error()", () => {
+    const err = new Error("oops");
+    logger.error("fail", err, { extra: "data" });
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.error.message).toBe("oops");
+    expect(parsed.extra).toBe("data");
+  });
+
+  it("handles error() without an Error object", () => {
+    logger.error("just a message", undefined, { info: "value" });
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.info).toBe("value");
+  });
+
+  it("output is newline-terminated", () => {
+    logger.info("test");
+    const output = stdoutSpy.mock.calls[0]![0] as string;
+    expect(output.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("LedgerLoggerAdapter", () => {
+  let logger: Logger;
+  let adapter: LedgerLoggerAdapter;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logger = new Logger();
+    adapter = new LedgerLoggerAdapter(logger);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it("forwards debug with context: 'ledger'", () => {
+    adapter.debug("ledger debug");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.context).toBe("ledger");
+    expect(parsed.level).toBe("DEBUG");
+  });
+
+  it("forwards info with context: 'ledger'", () => {
+    adapter.info("ledger info");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.context).toBe("ledger");
+    expect(parsed.level).toBe("INFO");
+  });
+
+  it("forwards warn with context: 'ledger'", () => {
+    adapter.warn("ledger warn");
+    const parsed = JSON.parse((stderrSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.context).toBe("ledger");
+    expect(parsed.level).toBe("WARN");
+  });
+
+  it("extracts Error from args in error()", () => {
+    const err = new Error("ledger error");
+    adapter.error("failed", err, "extra-arg");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.error.message).toBe("ledger error");
+    expect(parsed.context).toBe("ledger");
+  });
+
+  it("forwards error without Error in args", () => {
+    adapter.error("no error object", "some-string");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.context).toBe("ledger");
+  });
+
+  it("forwards log() as info", () => {
+    adapter.log("log message");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.level).toBe("INFO");
+    expect(parsed.context).toBe("ledger");
+  });
+
+  it("formatArgs returns undefined for empty args", () => {
+    adapter.debug("no args");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.args).toBeUndefined();
+  });
+
+  it("formatArgs returns single arg unwrapped", () => {
+    adapter.debug("one arg", "single");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.args).toBe("single");
+  });
+
+  it("formatArgs returns array for multiple args", () => {
+    adapter.debug("multi args", "a", "b");
+    const parsed = JSON.parse((stdoutSpy.mock.calls[0]![0] as string).trim());
+    expect(parsed.args).toEqual(["a", "b"]);
+  });
+});

--- a/server/src/__tests__/sha256.test.ts
+++ b/server/src/__tests__/sha256.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { sha256 } from "../sha256.js";
+
+describe("sha256", () => {
+  it("hashes an empty string", () => {
+    expect(sha256("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+
+  it("hashes 'hello'", () => {
+    expect(sha256("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+  });
+
+  it("hashes 'abc'", () => {
+    expect(sha256("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+  });
+
+  it("handles unicode characters", () => {
+    const result = sha256("Hello, 世界!");
+    expect(result).toHaveLength(64);
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns consistent results for the same input", () => {
+    const input = "test-consistency";
+    expect(sha256(input)).toBe(sha256(input));
+  });
+
+  it("returns different results for different inputs", () => {
+    expect(sha256("input1")).not.toBe(sha256("input2"));
+  });
+});

--- a/server/src/acs/activeContractsService.ts
+++ b/server/src/acs/activeContractsService.ts
@@ -1,0 +1,422 @@
+import {
+  Ledger,
+  CreateEvent,
+  Interface,
+  MultiStream,
+  InterfaceMultiStream,
+  Stream,
+  TemplateMapping,
+  InterfaceMapping,
+  PackageIdString,
+  VersionedRegistry,
+} from "@c7-digital/ledger";
+import { ContractId, Party, Template, InterfaceCompanion } from "@daml/types";
+import { TemplateTracker } from "./templateTracker.js";
+import { InterfaceTracker } from "./interfaceTracker.js";
+import { TypeSafeTrackerRegistry, TypeSafeInterfaceTrackerRegistry } from "./registries.js";
+import type { TrackerRegistry, InterfaceTrackerRegistry, PayloadOf, AcsLogger } from "./types.js";
+import { noOpLogger } from "./types.js";
+
+export interface ActiveContractsServiceOptions {
+  ledgerUrl?: string;
+  versionedRegistry: VersionedRegistry;
+  logger?: AcsLogger;
+}
+
+export class ActiveContractsService {
+  private trackers: TrackerRegistry = new TypeSafeTrackerRegistry();
+  private interfaceTrackers: InterfaceTrackerRegistry = new TypeSafeInterfaceTrackerRegistry();
+  private multiStream?: MultiStream<any>;
+  private interfaceMultiStream?: InterfaceMultiStream<any>;
+  private templateMapping: TemplateMapping = {};
+  private interfaceMapping: InterfaceMapping = {};
+  private ledger?: Ledger;
+  private readAsParties: Party[] = [];
+  private isInitialized = false;
+  private ledgerUrl?: string;
+  private hasAcs = false;
+  private versionedRegistry: VersionedRegistry;
+  private logger: AcsLogger;
+
+  // Strong references to prevent garbage collection
+  private activeStreams: Set<Stream<any, any>> = new Set();
+  private activeMultiStreams: Set<MultiStream<any>> = new Set();
+
+  constructor(options: ActiveContractsServiceOptions) {
+    this.ledgerUrl = options.ledgerUrl;
+    this.versionedRegistry = options.versionedRegistry;
+    this.logger = options.logger ?? noOpLogger;
+  }
+
+  public setLedgerUrl(ledgerUrl: string): void {
+    this.ledgerUrl = ledgerUrl;
+  }
+
+  public getLedger(): Ledger | undefined {
+    return this.ledger;
+  }
+
+  public async initWithToken(token: string): Promise<void> {
+    if (!this.ledgerUrl) {
+      throw new Error("Ledger URL must be set before initializing");
+    }
+
+    this.logger.info(`Initializing ActiveContractsService with token`, {
+      tokenLength: token?.length || 0,
+      ledgerUrl: this.ledgerUrl,
+    });
+
+    try {
+      await this.cleanupStream();
+
+      const ledgerOptions = {
+        token: token,
+        httpBaseUrl: this.ledgerUrl.endsWith("/") ? this.ledgerUrl.slice(0, -1) : this.ledgerUrl,
+        validation: "logErrors" as const,
+        versionedRegistry: this.versionedRegistry,
+      };
+
+      this.logger.debug(`Ledger options`, { ledgerOptions });
+      this.ledger = new Ledger(ledgerOptions);
+
+      const userInfo = await this.ledger.getTokenUserInfo();
+      this.logger.info(`User info`, { userInfo });
+      this.readAsParties =
+        userInfo?.rights
+          ?.filter(right => right.type === "canReadAs" || right.type === "canActAs")
+          .map(right => right.party) || [];
+
+      await this.initMultiStream();
+
+      this.isInitialized = true;
+
+      this.logger.info(
+        `ActiveContractsService initialized with ${Array.from(this.trackers.keys()).length} contract types`
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error initializing ActiveContractsService: ${JSON.stringify(error)}`,
+        error as Error
+      );
+      throw error;
+    }
+  }
+
+  public getTracker<T extends Template<any, any, any>>(
+    contractTemplate: T
+  ): TemplateTracker<PayloadOf<T>> {
+    const templateId = contractTemplate.templateId as PackageIdString;
+    const tracker = this.trackers.get(templateId) as TemplateTracker<PayloadOf<T>> | undefined;
+
+    if (!tracker) {
+      throw new Error(
+        `Contract type ${templateId} is not registered. ` +
+          `Use registerTemplate before trying to access the tracker.`
+      );
+    }
+
+    return tracker;
+  }
+
+  public registerTemplate<T extends Template<any, any, any>>(
+    contractTemplate: T,
+    relevanceFn?: (payload: PayloadOf<T>) => boolean
+  ): TemplateTracker<PayloadOf<T>> {
+    if (this.isInitialized) {
+      throw new Error(
+        `Cannot register template ${contractTemplate.templateId} after initialization. ` +
+          `Register all templates before calling initWithToken.`
+      );
+    }
+
+    const templateId = contractTemplate.templateId as PackageIdString;
+
+    if (this.trackers.has(templateId)) {
+      throw new Error(`Template ${templateId} is already registered`);
+    }
+
+    const tracker = new TemplateTracker<PayloadOf<T>>(contractTemplate, this.logger, relevanceFn);
+    this.trackers.set(templateId, tracker);
+
+    this.templateMapping[templateId] = {
+      contractType: {} as T,
+      keyType: undefined,
+    };
+
+    this.logger.debug(`Registered template ${templateId}`);
+    return tracker;
+  }
+
+  public registerInterface<I extends InterfaceCompanion<any, any, any>>(
+    contractInterface: I,
+    relevanceFn?: (view: PayloadOf<I>) => boolean
+  ): InterfaceTracker<PayloadOf<I>> {
+    if (this.isInitialized) {
+      throw new Error(
+        `Cannot register interface ${contractInterface.templateId} after initialization. ` +
+          `Register all interfaces before calling initWithToken.`
+      );
+    }
+
+    const interfaceId = contractInterface.templateId as PackageIdString;
+
+    if (this.interfaceTrackers.has(interfaceId)) {
+      throw new Error(`Interface ${interfaceId} is already registered`);
+    }
+
+    const tracker = new InterfaceTracker<PayloadOf<I>>(contractInterface, this.logger, relevanceFn);
+    this.interfaceTrackers.set(interfaceId, tracker);
+
+    this.interfaceMapping[interfaceId] = {
+      contractType: {} as PayloadOf<I>,
+    };
+
+    this.logger.debug(`Registered interface ${interfaceId}`);
+    return tracker;
+  }
+
+  public getInterfaceTracker<I extends InterfaceCompanion<any, any, any>>(
+    contractInterface: I
+  ): InterfaceTracker<PayloadOf<I>> {
+    const interfaceId = contractInterface.templateId as PackageIdString;
+    const tracker = this.interfaceTrackers.get(interfaceId) as InterfaceTracker<PayloadOf<I>> | undefined;
+
+    if (!tracker) {
+      throw new Error(
+        `Interface type ${interfaceId} is not registered. ` +
+          `Use registerInterface before trying to access the tracker.`
+      );
+    }
+
+    return tracker;
+  }
+
+  private async initMultiStream(): Promise<void> {
+    if (!this.ledger) {
+      throw new Error("Ledger must be initialized before calling initMultiStream");
+    }
+
+    this.logger.info(`Initializing MultiStream for ${this.trackers.length()} templates`);
+
+    try {
+      this.multiStream = await this.ledger.createMultiStream<TemplateMapping>(
+        this.templateMapping,
+        "end",
+        this.hasAcs,
+        false,
+        this.readAsParties
+      );
+
+      // Add to strong reference set to prevent garbage collection
+      this.activeMultiStreams.add(this.multiStream);
+
+      this.multiStream.onState(state => {
+        this.logger.info(`MultiStream state: ${state}`);
+        if (state === "live") {
+          this.hasAcs = true;
+        }
+      });
+
+      for (const templateId of this.trackers.keys()) {
+        const tracker = this.trackers.get(templateId)!;
+
+        this.multiStream.onCreate(templateId, event => {
+          tracker.handleContractCreated(event);
+        });
+
+        this.multiStream.onArchive(templateId, event => {
+          tracker.handleContractArchived(event.contractId);
+        });
+      }
+
+      this.multiStream.onError(error => {
+        this.logger.error(`MultiStream error: ${JSON.stringify(error)}`);
+      });
+
+      this.multiStream.start();
+
+      this.logger.info(`Started MultiStream for ${this.trackers.length()} templates`);
+
+      if (this.interfaceTrackers.length() > 0) {
+        await this.initInterfaceMultiStream();
+      }
+    } catch (error) {
+      this.logger.error(`Error initializing MultiStream`, error as Error);
+      throw error;
+    }
+  }
+
+  private async initInterfaceMultiStream(): Promise<void> {
+    if (!this.ledger) {
+      throw new Error("Ledger must be initialized before calling initInterfaceMultiStream");
+    }
+
+    this.logger.info(`Initializing InterfaceMultiStream for ${this.interfaceTrackers.length()} interfaces`);
+
+    try {
+      this.interfaceMultiStream = await this.ledger.createMultiInterfaceStream<InterfaceMapping>(
+        this.interfaceMapping,
+        "end",
+        this.hasAcs,
+        false,
+        this.readAsParties
+      );
+
+      this.interfaceMultiStream.onState(state => {
+        this.logger.info(`InterfaceMultiStream state: ${state}`);
+        if (state === "live") {
+          this.hasAcs = true;
+        }
+      });
+
+      for (const interfaceId of this.interfaceTrackers.keys()) {
+        const tracker = this.interfaceTrackers.get(interfaceId)!;
+
+        this.interfaceMultiStream.onInterfaceView(interfaceId, event => {
+          tracker.handleInterfaceViewed(event);
+        });
+
+        this.interfaceMultiStream.onArchive(interfaceId, event => {
+          tracker.handleInterfaceArchived(event.contractId);
+        });
+      }
+
+      this.interfaceMultiStream.onError(error => {
+        this.logger.error(`InterfaceMultiStream error: ${JSON.stringify(error)}`);
+      });
+
+      this.interfaceMultiStream.start();
+
+      this.logger.info(`Started InterfaceMultiStream for ${this.interfaceTrackers.length()} interfaces`);
+    } catch (error) {
+      this.logger.error(`Error initializing InterfaceMultiStream`, error as Error);
+      throw error;
+    }
+  }
+
+  // Convenience methods
+  public getPayload<T extends Template<any, any, any>>(
+    contractTemplate: T,
+    contractId: ContractId<PayloadOf<T>>
+  ): PayloadOf<T> | undefined {
+    const tracker = this.getTracker(contractTemplate);
+    return tracker.getPayload(contractId);
+  }
+
+  public getAllPayloads<T extends Template<any, any, any>>(
+    contractTemplate: T
+  ): Map<ContractId<PayloadOf<T>>, PayloadOf<T>> | undefined {
+    const tracker = this.getTracker(contractTemplate);
+    return tracker.getAllContracts();
+  }
+
+  public getContractCount(contractTemplate: Template<any, any, any>): number {
+    const tracker = this.getTracker(contractTemplate);
+    return tracker.getContractCount();
+  }
+
+  public getAllCreateEvents<T extends Template<any, any, any>>(
+    contractTemplate: T
+  ): Map<ContractId<T>, CreateEvent<PayloadOf<T>>> {
+    const tracker = this.getTracker(contractTemplate);
+    return tracker.getAllCreateEvents();
+  }
+
+  public getIsInitialized(): boolean {
+    return this.isInitialized;
+  }
+
+  public getRegisteredContractTypes(): PackageIdString[] {
+    return Array.from(this.trackers.keys());
+  }
+
+  // Interface convenience methods
+  public getInterfaceView<I extends InterfaceCompanion<any, any, any>>(
+    contractInterface: I,
+    contractId: ContractId<PayloadOf<I>>
+  ): PayloadOf<I> | undefined {
+    const tracker = this.getInterfaceTracker(contractInterface);
+    return tracker.getView(contractId);
+  }
+
+  public getAllInterfaceViews<I extends InterfaceCompanion<any, any, any>>(
+    contractInterface: I
+  ): Map<ContractId<PayloadOf<I>>, PayloadOf<I>> | undefined {
+    const tracker = this.getInterfaceTracker(contractInterface);
+    return tracker.getAllInterfaces();
+  }
+
+  public getInterfaceCount<I extends InterfaceCompanion<any, any, any>>(contractInterface: I): number {
+    const tracker = this.getInterfaceTracker(contractInterface);
+    return tracker.getInterfaceCount();
+  }
+
+  public getAllInterfaceEvents<I extends InterfaceCompanion<any, any, any>>(
+    contractInterface: I
+  ): Map<ContractId<PayloadOf<I>>, Interface<PayloadOf<I>>> {
+    const tracker = this.getInterfaceTracker(contractInterface);
+    return tracker.getAllInterfaceEvents();
+  }
+
+  public getRegisteredInterfaceTypes(): PackageIdString[] {
+    return Array.from(this.interfaceTrackers.keys());
+  }
+
+  /**
+   * Add a stream to the strong reference tracking to prevent garbage collection.
+   * Use this when creating individual streams outside of the main MultiStream.
+   */
+  public addStreamReference(stream: Stream<any, any>): void {
+    this.activeStreams.add(stream);
+    this.logger.debug(`Added stream reference, total active streams: ${this.activeStreams.size}`);
+  }
+
+  /**
+   * Remove a stream from strong reference tracking (usually when it's manually closed).
+   */
+  public removeStreamReference(stream: Stream<any, any>): void {
+    const removed = this.activeStreams.delete(stream);
+    if (removed) {
+      this.logger.debug(`Removed stream reference, total active streams: ${this.activeStreams.size}`);
+    }
+  }
+
+  public async cleanupStream(): Promise<void> {
+    this.logger.info("Cleaning up ActiveContractsService");
+
+    if (this.multiStream) {
+      this.multiStream.close();
+      this.activeMultiStreams.delete(this.multiStream);
+      this.multiStream = undefined;
+    }
+
+    if (this.interfaceMultiStream) {
+      this.interfaceMultiStream.close();
+      this.interfaceMultiStream = undefined;
+    }
+
+    // Clean up all active streams
+    for (const stream of this.activeStreams) {
+      try {
+        stream.close();
+      } catch (error) {
+        this.logger.warn("Error closing stream during cleanup", error as any);
+      }
+    }
+    this.activeStreams.clear();
+
+    // Clean up all active multi-streams
+    for (const multiStream of this.activeMultiStreams) {
+      try {
+        multiStream.close();
+      } catch (error) {
+        this.logger.warn("Error closing multi-stream during cleanup", error as any);
+      }
+    }
+    this.activeMultiStreams.clear();
+
+    // Do NOT clean up tracker state as they retain state across token changes
+    this.isInitialized = false;
+    this.ledger = undefined;
+  }
+}

--- a/server/src/acs/baseTracker.ts
+++ b/server/src/acs/baseTracker.ts
@@ -1,0 +1,195 @@
+import { ContractId } from "@daml/types";
+import type { PackageIdString } from "@c7-digital/ledger";
+import type { AcsLogger } from "./types.js";
+
+export interface BaseTrackerConfig {
+  identifier: PackageIdString;
+  entityLabel: string;
+  idLabel: string;
+  addedVerb: string;
+  dataLabel: string;
+}
+
+export type AddedCallback<T extends object, TEvent> = (
+  contractId: ContractId<T>,
+  data: T,
+  event: TEvent,
+) => Promise<void> | void;
+
+export type ArchivedCallback<T extends object> = (
+  contractId: ContractId<T>,
+  data: T,
+) => Promise<void> | void;
+
+export abstract class BaseTracker<T extends object, TEvent> {
+  private eventMap = new Map<ContractId<T>, TEvent>();
+  private addedCallbacks: Map<string, AddedCallback<T, TEvent>> = new Map();
+  private archivedCallbacks: Map<string, ArchivedCallback<T>> = new Map();
+  private firstSeenAtMap = new Map<ContractId<T>, string>();
+  private relevanceFn?: (data: T) => boolean;
+  private logger: AcsLogger;
+  private config: BaseTrackerConfig;
+
+  constructor(
+    config: BaseTrackerConfig,
+    logger: AcsLogger,
+    relevanceFn?: (data: T) => boolean,
+  ) {
+    this.config = config;
+    this.logger = logger;
+    this.relevanceFn = relevanceFn;
+  }
+
+  protected abstract extractData(event: TEvent): T;
+  protected abstract extractContractId(event: TEvent): ContractId<T>;
+
+  protected getDataByContractId(contractId: ContractId<T>): T | undefined {
+    const event = this.eventMap.get(contractId);
+    return event ? this.extractData(event) : undefined;
+  }
+
+  protected getEventByContractId(contractId: ContractId<T>): TEvent | undefined {
+    return this.eventMap.get(contractId);
+  }
+
+  protected getAllDataEntries(): Map<ContractId<T>, T> {
+    const result = new Map<ContractId<T>, T>();
+    for (const [contractId, event] of this.eventMap.entries()) {
+      result.set(contractId, this.extractData(event));
+    }
+    return result;
+  }
+
+  protected getAllEventEntries(): Map<ContractId<T>, TEvent> {
+    return new Map(this.eventMap);
+  }
+
+  protected getAllEntriesWithMeta(): Array<{
+    contractId: ContractId<T>;
+    data: T;
+    firstSeenAt: string;
+  }> {
+    const out: Array<{
+      contractId: ContractId<T>;
+      data: T;
+      firstSeenAt: string;
+    }> = [];
+    for (const [id, event] of this.eventMap.entries()) {
+      const ts = this.firstSeenAtMap.get(id) ?? new Date().toISOString();
+      out.push({
+        contractId: id,
+        data: this.extractData(event),
+        firstSeenAt: ts,
+      });
+    }
+    return out;
+  }
+
+  protected hasEntry(contractId: ContractId<T>): boolean {
+    return this.eventMap.has(contractId);
+  }
+
+  protected getEntryCount(): number {
+    return this.eventMap.size;
+  }
+
+  protected getIdentifier(): PackageIdString {
+    return this.config.identifier;
+  }
+
+  protected registerAddedCallback(key: string, callback: AddedCallback<T, TEvent>): void {
+    if (this.addedCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.addedCallbacks.set(key, callback);
+  }
+
+  protected removeAddedCallback(key: string): void {
+    this.addedCallbacks.delete(key);
+  }
+
+  protected registerArchivedCallback(key: string, callback: ArchivedCallback<T>): void {
+    if (this.archivedCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.archivedCallbacks.set(key, callback);
+  }
+
+  protected removeRegisteredArchivedCallback(key: string): void {
+    this.archivedCallbacks.delete(key);
+  }
+
+  protected async handleEventAdded(event: TEvent): Promise<void> {
+    const contractId = this.extractContractId(event);
+    const data = this.extractData(event);
+    const { entityLabel, idLabel, identifier, addedVerb, dataLabel } = this.config;
+
+    if (this.relevanceFn && !this.relevanceFn(data)) {
+      this.logger.warn(`Ignoring irrelevant ${entityLabel}`, {
+        [idLabel]: identifier,
+        contractId: contractId.toString(),
+        [dataLabel]: data,
+      });
+      return;
+    }
+
+    const capitalized = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1);
+    this.logger.debug(`${capitalized} ${addedVerb}`, {
+      [idLabel]: identifier,
+      contractId: contractId.toString(),
+    });
+
+    this.eventMap.set(contractId, event);
+
+    if (!this.firstSeenAtMap.has(contractId)) {
+      this.firstSeenAtMap.set(contractId, new Date().toISOString());
+    }
+
+    for (const [, callback] of this.addedCallbacks) {
+      try {
+        await callback(contractId, data, event);
+      } catch (error) {
+        this.logger.error(
+          `Error executing ${addedVerb} callback for ${identifier}`,
+          error as Error,
+          { contractId: contractId.toString() }
+        );
+      }
+    }
+  }
+
+  protected async handleEventArchived(contractId: ContractId<T>): Promise<void> {
+    const { entityLabel, idLabel, identifier } = this.config;
+    const capitalized = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1);
+
+    this.logger.debug(`${capitalized} archived`, {
+      [idLabel]: identifier,
+      contractId: contractId.toString(),
+    });
+
+    const event = this.eventMap.get(contractId);
+    if (event) {
+      const data = this.extractData(event);
+      this.eventMap.delete(contractId);
+      this.firstSeenAtMap.delete(contractId);
+
+      for (const [, callback] of this.archivedCallbacks) {
+        try {
+          await callback(contractId, data);
+        } catch (error) {
+          this.logger.error(
+            `Error executing archived callback for ${identifier}`,
+            error as Error,
+            { contractId: contractId.toString() }
+          );
+        }
+      }
+    }
+  }
+
+  public cleanup(): void {
+    this.eventMap.clear();
+    this.addedCallbacks.clear();
+    this.archivedCallbacks.clear();
+  }
+}

--- a/server/src/acs/index.ts
+++ b/server/src/acs/index.ts
@@ -1,0 +1,16 @@
+export { ActiveContractsService, type ActiveContractsServiceOptions } from "./activeContractsService.js";
+export { TemplateTracker } from "./templateTracker.js";
+export { InterfaceTracker } from "./interfaceTracker.js";
+export { TypeSafeTrackerRegistry, TypeSafeInterfaceTrackerRegistry } from "./registries.js";
+export type {
+  PayloadOf,
+  AcsLogger,
+  ContractCreatedCallback,
+  ContractArchivedCallback,
+  InterfaceViewedCallback,
+  InterfaceArchivedCallback,
+  ContractWithPayload,
+  TrackerRegistry,
+  InterfaceTrackerRegistry,
+} from "./types.js";
+export { noOpLogger } from "./types.js";

--- a/server/src/acs/index.ts
+++ b/server/src/acs/index.ts
@@ -1,4 +1,5 @@
 export { ActiveContractsService, type ActiveContractsServiceOptions } from "./activeContractsService.js";
+export { BaseTracker } from "./baseTracker.js";
 export { TemplateTracker } from "./templateTracker.js";
 export { InterfaceTracker } from "./interfaceTracker.js";
 export { TypeSafeTrackerRegistry, TypeSafeInterfaceTrackerRegistry } from "./registries.js";

--- a/server/src/acs/interfaceTracker.ts
+++ b/server/src/acs/interfaceTracker.ts
@@ -1,45 +1,49 @@
 import { ContractId, InterfaceCompanion } from "@daml/types";
 import { Interface, PackageIdString } from "@c7-digital/ledger";
 import type { InterfaceViewedCallback, InterfaceArchivedCallback, AcsLogger } from "./types.js";
+import { BaseTracker } from "./baseTracker.js";
 
-export class InterfaceTracker<I extends object> {
-  private interfaceMap = new Map<ContractId<I>, Interface<I>>();
-  private viewedCallbacks: Map<string, InterfaceViewedCallback<I>> = new Map();
-  private archivedCallbacks: Map<string, InterfaceArchivedCallback<I>> = new Map();
-  private contractInterface: InterfaceCompanion<I, any, PackageIdString>;
-  private relevanceFn?: (view: I) => boolean;
-  private firstSeenAtMap = new Map<ContractId<I>, string>();
-  private logger: AcsLogger;
-
+export class InterfaceTracker<I extends object> extends BaseTracker<I, Interface<I>> {
   constructor(
     contractInterface: InterfaceCompanion<I, any, PackageIdString>,
     logger: AcsLogger,
     relevanceFn?: (view: I) => boolean,
   ) {
-    this.contractInterface = contractInterface;
-    this.logger = logger;
-    this.relevanceFn = relevanceFn;
+    super(
+      {
+        identifier: contractInterface.templateId,
+        entityLabel: "interface",
+        idLabel: "interfaceId",
+        addedVerb: "viewed",
+        dataLabel: "view",
+      },
+      logger,
+      relevanceFn,
+    );
+  }
+
+  protected extractData(event: Interface<I>): I {
+    return event.interfaceView;
+  }
+
+  protected extractContractId(event: Interface<I>): ContractId<I> {
+    return event.contractId;
   }
 
   public getView(contractId: ContractId<I>): I | undefined {
-    const interfaceEvent = this.interfaceMap.get(contractId);
-    return interfaceEvent?.interfaceView;
+    return this.getDataByContractId(contractId);
   }
 
   public getInterfaceEvent(contractId: ContractId<I>): Interface<I> | undefined {
-    return this.interfaceMap.get(contractId);
+    return this.getEventByContractId(contractId);
   }
 
   public getAllInterfaces(): Map<ContractId<I>, I> {
-    const result = new Map<ContractId<I>, I>();
-    for (const [contractId, interfaceEvent] of this.interfaceMap.entries()) {
-      result.set(contractId, interfaceEvent.interfaceView);
-    }
-    return result;
+    return this.getAllDataEntries();
   }
 
   public getAllInterfaceEvents(): Map<ContractId<I>, Interface<I>> {
-    return new Map(this.interfaceMap);
+    return this.getAllEventEntries();
   }
 
   public getAllInterfacesWithMeta(): Array<{
@@ -47,121 +51,46 @@ export class InterfaceTracker<I extends object> {
     view: I;
     firstSeenAt: string;
   }> {
-    const out: Array<{
-      contractId: ContractId<I>;
-      view: I;
-      firstSeenAt: string;
-    }> = [];
-    for (const [id, interfaceEvent] of this.interfaceMap.entries()) {
-      const ts = this.firstSeenAtMap.get(id) ?? new Date().toISOString();
-      out.push({
-        contractId: id,
-        view: interfaceEvent.interfaceView,
-        firstSeenAt: ts,
-      });
-    }
-    return out;
+    return this.getAllEntriesWithMeta().map(({ contractId, data, firstSeenAt }) => ({
+      contractId,
+      view: data,
+      firstSeenAt,
+    }));
   }
 
   public hasInterface(contractId: ContractId<I>): boolean {
-    return this.interfaceMap.has(contractId);
+    return this.hasEntry(contractId);
   }
 
   public getInterfaceCount(): number {
-    return this.interfaceMap.size;
+    return this.getEntryCount();
   }
 
   public getInterfaceId(): PackageIdString {
-    return this.contractInterface.templateId;
+    return this.getIdentifier();
   }
 
   public onViewed(key: string, callback: InterfaceViewedCallback<I>): void {
-    if (this.viewedCallbacks.has(key)) {
-      throw new Error(`Callback with key ${key} already exists`);
-    }
-    this.viewedCallbacks.set(key, callback);
+    this.registerAddedCallback(key, callback);
   }
 
   public removeViewedCallback(key: string): void {
-    this.viewedCallbacks.delete(key);
+    this.removeAddedCallback(key);
   }
 
   public onArchived(key: string, callback: InterfaceArchivedCallback<I>): void {
-    if (this.archivedCallbacks.has(key)) {
-      throw new Error(`Callback with key ${key} already exists`);
-    }
-    this.archivedCallbacks.set(key, callback);
+    this.registerArchivedCallback(key, callback);
   }
 
   public removeArchivedCallback(key: string): void {
-    this.archivedCallbacks.delete(key);
+    this.removeRegisteredArchivedCallback(key);
   }
 
   public async handleInterfaceViewed(interfaceEvent: Interface<I>): Promise<void> {
-    const { contractId, interfaceView: view } = interfaceEvent;
-
-    if (this.relevanceFn && !this.relevanceFn(view)) {
-      this.logger.warn(`Ignoring irrelevant interface`, {
-        interfaceId: this.contractInterface.templateId,
-        contractId: contractId.toString(),
-        view,
-      });
-      return;
-    }
-
-    this.logger.debug(`Interface viewed`, {
-      interfaceId: this.contractInterface.templateId,
-      contractId: contractId.toString(),
-    });
-
-    this.interfaceMap.set(contractId, interfaceEvent);
-
-    if (!this.firstSeenAtMap.has(contractId)) {
-      this.firstSeenAtMap.set(contractId, new Date().toISOString());
-    }
-
-    for (const [, callback] of this.viewedCallbacks) {
-      try {
-        await callback(contractId, view, interfaceEvent);
-      } catch (error) {
-        this.logger.error(
-          `Error executing viewed callback for ${this.contractInterface.templateId}`,
-          error as Error,
-          { contractId: contractId.toString() }
-        );
-      }
-    }
+    return this.handleEventAdded(interfaceEvent);
   }
 
   public async handleInterfaceArchived(contractId: ContractId<I>): Promise<void> {
-    this.logger.debug(`Interface archived`, {
-      interfaceId: this.contractInterface.templateId,
-      contractId: contractId.toString(),
-    });
-
-    const interfaceEvent = this.interfaceMap.get(contractId);
-    if (interfaceEvent) {
-      const view = interfaceEvent.interfaceView;
-      this.interfaceMap.delete(contractId);
-      this.firstSeenAtMap.delete(contractId);
-
-      for (const [, callback] of this.archivedCallbacks) {
-        try {
-          await callback(contractId, view);
-        } catch (error) {
-          this.logger.error(
-            `Error executing archived callback for ${this.contractInterface.templateId}`,
-            error as Error,
-            { contractId: contractId.toString() }
-          );
-        }
-      }
-    }
-  }
-
-  public cleanup(): void {
-    this.interfaceMap.clear();
-    this.viewedCallbacks.clear();
-    this.archivedCallbacks.clear();
+    return this.handleEventArchived(contractId);
   }
 }

--- a/server/src/acs/interfaceTracker.ts
+++ b/server/src/acs/interfaceTracker.ts
@@ -1,0 +1,167 @@
+import { ContractId, InterfaceCompanion } from "@daml/types";
+import { Interface, PackageIdString } from "@c7-digital/ledger";
+import type { InterfaceViewedCallback, InterfaceArchivedCallback, AcsLogger } from "./types.js";
+
+export class InterfaceTracker<I extends object> {
+  private interfaceMap = new Map<ContractId<I>, Interface<I>>();
+  private viewedCallbacks: Map<string, InterfaceViewedCallback<I>> = new Map();
+  private archivedCallbacks: Map<string, InterfaceArchivedCallback<I>> = new Map();
+  private contractInterface: InterfaceCompanion<I, any, PackageIdString>;
+  private relevanceFn?: (view: I) => boolean;
+  private firstSeenAtMap = new Map<ContractId<I>, string>();
+  private logger: AcsLogger;
+
+  constructor(
+    contractInterface: InterfaceCompanion<I, any, PackageIdString>,
+    logger: AcsLogger,
+    relevanceFn?: (view: I) => boolean,
+  ) {
+    this.contractInterface = contractInterface;
+    this.logger = logger;
+    this.relevanceFn = relevanceFn;
+  }
+
+  public getView(contractId: ContractId<I>): I | undefined {
+    const interfaceEvent = this.interfaceMap.get(contractId);
+    return interfaceEvent?.interfaceView;
+  }
+
+  public getInterfaceEvent(contractId: ContractId<I>): Interface<I> | undefined {
+    return this.interfaceMap.get(contractId);
+  }
+
+  public getAllInterfaces(): Map<ContractId<I>, I> {
+    const result = new Map<ContractId<I>, I>();
+    for (const [contractId, interfaceEvent] of this.interfaceMap.entries()) {
+      result.set(contractId, interfaceEvent.interfaceView);
+    }
+    return result;
+  }
+
+  public getAllInterfaceEvents(): Map<ContractId<I>, Interface<I>> {
+    return new Map(this.interfaceMap);
+  }
+
+  public getAllInterfacesWithMeta(): Array<{
+    contractId: ContractId<I>;
+    view: I;
+    firstSeenAt: string;
+  }> {
+    const out: Array<{
+      contractId: ContractId<I>;
+      view: I;
+      firstSeenAt: string;
+    }> = [];
+    for (const [id, interfaceEvent] of this.interfaceMap.entries()) {
+      const ts = this.firstSeenAtMap.get(id) ?? new Date().toISOString();
+      out.push({
+        contractId: id,
+        view: interfaceEvent.interfaceView,
+        firstSeenAt: ts,
+      });
+    }
+    return out;
+  }
+
+  public hasInterface(contractId: ContractId<I>): boolean {
+    return this.interfaceMap.has(contractId);
+  }
+
+  public getInterfaceCount(): number {
+    return this.interfaceMap.size;
+  }
+
+  public getInterfaceId(): PackageIdString {
+    return this.contractInterface.templateId;
+  }
+
+  public onViewed(key: string, callback: InterfaceViewedCallback<I>): void {
+    if (this.viewedCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.viewedCallbacks.set(key, callback);
+  }
+
+  public removeViewedCallback(key: string): void {
+    this.viewedCallbacks.delete(key);
+  }
+
+  public onArchived(key: string, callback: InterfaceArchivedCallback<I>): void {
+    if (this.archivedCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.archivedCallbacks.set(key, callback);
+  }
+
+  public removeArchivedCallback(key: string): void {
+    this.archivedCallbacks.delete(key);
+  }
+
+  public async handleInterfaceViewed(interfaceEvent: Interface<I>): Promise<void> {
+    const { contractId, interfaceView: view } = interfaceEvent;
+
+    if (this.relevanceFn && !this.relevanceFn(view)) {
+      this.logger.warn(`Ignoring irrelevant interface`, {
+        interfaceId: this.contractInterface.templateId,
+        contractId: contractId.toString(),
+        view,
+      });
+      return;
+    }
+
+    this.logger.debug(`Interface viewed`, {
+      interfaceId: this.contractInterface.templateId,
+      contractId: contractId.toString(),
+    });
+
+    this.interfaceMap.set(contractId, interfaceEvent);
+
+    if (!this.firstSeenAtMap.has(contractId)) {
+      this.firstSeenAtMap.set(contractId, new Date().toISOString());
+    }
+
+    for (const [, callback] of this.viewedCallbacks) {
+      try {
+        await callback(contractId, view, interfaceEvent);
+      } catch (error) {
+        this.logger.error(
+          `Error executing viewed callback for ${this.contractInterface.templateId}`,
+          error as Error,
+          { contractId: contractId.toString() }
+        );
+      }
+    }
+  }
+
+  public async handleInterfaceArchived(contractId: ContractId<I>): Promise<void> {
+    this.logger.debug(`Interface archived`, {
+      interfaceId: this.contractInterface.templateId,
+      contractId: contractId.toString(),
+    });
+
+    const interfaceEvent = this.interfaceMap.get(contractId);
+    if (interfaceEvent) {
+      const view = interfaceEvent.interfaceView;
+      this.interfaceMap.delete(contractId);
+      this.firstSeenAtMap.delete(contractId);
+
+      for (const [, callback] of this.archivedCallbacks) {
+        try {
+          await callback(contractId, view);
+        } catch (error) {
+          this.logger.error(
+            `Error executing archived callback for ${this.contractInterface.templateId}`,
+            error as Error,
+            { contractId: contractId.toString() }
+          );
+        }
+      }
+    }
+  }
+
+  public cleanup(): void {
+    this.interfaceMap.clear();
+    this.viewedCallbacks.clear();
+    this.archivedCallbacks.clear();
+  }
+}

--- a/server/src/acs/registries.ts
+++ b/server/src/acs/registries.ts
@@ -1,0 +1,62 @@
+import { PackageIdString } from "@c7-digital/ledger";
+import type { TemplateTracker } from "./templateTracker.js";
+import type { InterfaceTracker } from "./interfaceTracker.js";
+import type { TrackerRegistry, InterfaceTrackerRegistry } from "./types.js";
+
+export class TypeSafeTrackerRegistry implements TrackerRegistry {
+  private internal = new Map<PackageIdString, TemplateTracker<any>>();
+
+  get<T extends object>(templateId: PackageIdString): TemplateTracker<T> | undefined {
+    const tracker = this.internal.get(templateId);
+    return tracker as TemplateTracker<T> | undefined;
+  }
+
+  set<T extends object>(templateId: PackageIdString, tracker: TemplateTracker<T>): void {
+    this.internal.set(templateId, tracker);
+  }
+
+  has(templateId: PackageIdString): boolean {
+    return this.internal.has(templateId);
+  }
+
+  length(): number {
+    return this.internal.size;
+  }
+
+  values(): Iterable<TemplateTracker<any>> {
+    return this.internal.values();
+  }
+
+  keys(): Iterable<PackageIdString> {
+    return this.internal.keys();
+  }
+}
+
+export class TypeSafeInterfaceTrackerRegistry implements InterfaceTrackerRegistry {
+  private internal = new Map<PackageIdString, InterfaceTracker<any>>();
+
+  get<T extends object>(interfaceId: PackageIdString): InterfaceTracker<T> | undefined {
+    const tracker = this.internal.get(interfaceId);
+    return tracker as InterfaceTracker<T> | undefined;
+  }
+
+  set<T extends object>(interfaceId: PackageIdString, tracker: InterfaceTracker<T>): void {
+    this.internal.set(interfaceId, tracker);
+  }
+
+  has(interfaceId: PackageIdString): boolean {
+    return this.internal.has(interfaceId);
+  }
+
+  length(): number {
+    return this.internal.size;
+  }
+
+  values(): Iterable<InterfaceTracker<any>> {
+    return this.internal.values();
+  }
+
+  keys(): Iterable<PackageIdString> {
+    return this.internal.keys();
+  }
+}

--- a/server/src/acs/templateTracker.ts
+++ b/server/src/acs/templateTracker.ts
@@ -1,0 +1,167 @@
+import { ContractId, Template } from "@daml/types";
+import { CreateEvent, PackageIdString } from "@c7-digital/ledger";
+import type { ContractCreatedCallback, ContractArchivedCallback, AcsLogger } from "./types.js";
+
+export class TemplateTracker<T extends object> {
+  private contractMap = new Map<ContractId<T>, CreateEvent<T>>();
+  private createdCallbacks: Map<string, ContractCreatedCallback<T>> = new Map();
+  private archivedCallbacks: Map<string, ContractArchivedCallback<T>> = new Map();
+  private contractTemplate: Template<T, any, PackageIdString>;
+  private relevanceFn?: (payload: T) => boolean;
+  private firstSeenAtMap = new Map<ContractId<T>, string>();
+  private logger: AcsLogger;
+
+  constructor(
+    contractTemplate: Template<T, any, PackageIdString>,
+    logger: AcsLogger,
+    relevanceFn?: (payload: T) => boolean,
+  ) {
+    this.contractTemplate = contractTemplate;
+    this.logger = logger;
+    this.relevanceFn = relevanceFn;
+  }
+
+  public getPayload(contractId: ContractId<T>): T | undefined {
+    const createEvent = this.contractMap.get(contractId);
+    return createEvent?.payload;
+  }
+
+  public getCreateEvent(contractId: ContractId<T>): CreateEvent<T> | undefined {
+    return this.contractMap.get(contractId);
+  }
+
+  public getAllContracts(): Map<ContractId<T>, T> {
+    const result = new Map<ContractId<T>, T>();
+    for (const [contractId, createEvent] of this.contractMap.entries()) {
+      result.set(contractId, createEvent.payload);
+    }
+    return result;
+  }
+
+  public getAllCreateEvents(): Map<ContractId<T>, CreateEvent<T>> {
+    return new Map(this.contractMap);
+  }
+
+  public getAllContractsWithMeta(): Array<{
+    contractId: ContractId<T>;
+    payload: T;
+    firstSeenAt: string;
+  }> {
+    const out: Array<{
+      contractId: ContractId<T>;
+      payload: T;
+      firstSeenAt: string;
+    }> = [];
+    for (const [id, createEvent] of this.contractMap.entries()) {
+      const ts = this.firstSeenAtMap.get(id) ?? new Date().toISOString();
+      out.push({
+        contractId: id,
+        payload: createEvent.payload,
+        firstSeenAt: ts,
+      });
+    }
+    return out;
+  }
+
+  public hasContract(contractId: ContractId<T>): boolean {
+    return this.contractMap.has(contractId);
+  }
+
+  public getContractCount(): number {
+    return this.contractMap.size;
+  }
+
+  public getTemplateId(): PackageIdString {
+    return this.contractTemplate.templateId;
+  }
+
+  public onCreated(key: string, callback: ContractCreatedCallback<T>): void {
+    if (this.createdCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.createdCallbacks.set(key, callback);
+  }
+
+  public removeCreatedCallback(key: string): void {
+    this.createdCallbacks.delete(key);
+  }
+
+  public onArchived(key: string, callback: ContractArchivedCallback<T>): void {
+    if (this.archivedCallbacks.has(key)) {
+      throw new Error(`Callback with key ${key} already exists`);
+    }
+    this.archivedCallbacks.set(key, callback);
+  }
+
+  public removeArchivedCallback(key: string): void {
+    this.archivedCallbacks.delete(key);
+  }
+
+  public async handleContractCreated(createEvent: CreateEvent<T>): Promise<void> {
+    const { contractId, payload } = createEvent;
+
+    if (this.relevanceFn && !this.relevanceFn(payload)) {
+      this.logger.warn(`Ignoring irrelevant contract`, {
+        templateId: this.contractTemplate.templateId,
+        contractId: contractId.toString(),
+        payload,
+      });
+      return;
+    }
+
+    this.logger.debug(`Contract created`, {
+      templateId: this.contractTemplate.templateId,
+      contractId: contractId.toString(),
+    });
+
+    this.contractMap.set(contractId, createEvent);
+
+    if (!this.firstSeenAtMap.has(contractId)) {
+      this.firstSeenAtMap.set(contractId, new Date().toISOString());
+    }
+
+    for (const [, callback] of this.createdCallbacks) {
+      try {
+        await callback(contractId, payload, createEvent);
+      } catch (error) {
+        this.logger.error(
+          `Error executing created callback for ${this.contractTemplate.templateId}`,
+          error as Error,
+          { contractId: contractId.toString() }
+        );
+      }
+    }
+  }
+
+  public async handleContractArchived(contractId: ContractId<T>): Promise<void> {
+    this.logger.debug(`Contract archived`, {
+      templateId: this.contractTemplate.templateId,
+      contractId: contractId.toString(),
+    });
+
+    const createEvent = this.contractMap.get(contractId);
+    if (createEvent) {
+      const payload = createEvent.payload;
+      this.contractMap.delete(contractId);
+      this.firstSeenAtMap.delete(contractId);
+
+      for (const [, callback] of this.archivedCallbacks) {
+        try {
+          await callback(contractId, payload);
+        } catch (error) {
+          this.logger.error(
+            `Error executing archived callback for ${this.contractTemplate.templateId}`,
+            error as Error,
+            { contractId: contractId.toString() }
+          );
+        }
+      }
+    }
+  }
+
+  public cleanup(): void {
+    this.contractMap.clear();
+    this.createdCallbacks.clear();
+    this.archivedCallbacks.clear();
+  }
+}

--- a/server/src/acs/templateTracker.ts
+++ b/server/src/acs/templateTracker.ts
@@ -1,45 +1,49 @@
 import { ContractId, Template } from "@daml/types";
 import { CreateEvent, PackageIdString } from "@c7-digital/ledger";
 import type { ContractCreatedCallback, ContractArchivedCallback, AcsLogger } from "./types.js";
+import { BaseTracker } from "./baseTracker.js";
 
-export class TemplateTracker<T extends object> {
-  private contractMap = new Map<ContractId<T>, CreateEvent<T>>();
-  private createdCallbacks: Map<string, ContractCreatedCallback<T>> = new Map();
-  private archivedCallbacks: Map<string, ContractArchivedCallback<T>> = new Map();
-  private contractTemplate: Template<T, any, PackageIdString>;
-  private relevanceFn?: (payload: T) => boolean;
-  private firstSeenAtMap = new Map<ContractId<T>, string>();
-  private logger: AcsLogger;
-
+export class TemplateTracker<T extends object> extends BaseTracker<T, CreateEvent<T>> {
   constructor(
     contractTemplate: Template<T, any, PackageIdString>,
     logger: AcsLogger,
     relevanceFn?: (payload: T) => boolean,
   ) {
-    this.contractTemplate = contractTemplate;
-    this.logger = logger;
-    this.relevanceFn = relevanceFn;
+    super(
+      {
+        identifier: contractTemplate.templateId,
+        entityLabel: "contract",
+        idLabel: "templateId",
+        addedVerb: "created",
+        dataLabel: "payload",
+      },
+      logger,
+      relevanceFn,
+    );
+  }
+
+  protected extractData(event: CreateEvent<T>): T {
+    return event.payload;
+  }
+
+  protected extractContractId(event: CreateEvent<T>): ContractId<T> {
+    return event.contractId;
   }
 
   public getPayload(contractId: ContractId<T>): T | undefined {
-    const createEvent = this.contractMap.get(contractId);
-    return createEvent?.payload;
+    return this.getDataByContractId(contractId);
   }
 
   public getCreateEvent(contractId: ContractId<T>): CreateEvent<T> | undefined {
-    return this.contractMap.get(contractId);
+    return this.getEventByContractId(contractId);
   }
 
   public getAllContracts(): Map<ContractId<T>, T> {
-    const result = new Map<ContractId<T>, T>();
-    for (const [contractId, createEvent] of this.contractMap.entries()) {
-      result.set(contractId, createEvent.payload);
-    }
-    return result;
+    return this.getAllDataEntries();
   }
 
   public getAllCreateEvents(): Map<ContractId<T>, CreateEvent<T>> {
-    return new Map(this.contractMap);
+    return this.getAllEventEntries();
   }
 
   public getAllContractsWithMeta(): Array<{
@@ -47,121 +51,46 @@ export class TemplateTracker<T extends object> {
     payload: T;
     firstSeenAt: string;
   }> {
-    const out: Array<{
-      contractId: ContractId<T>;
-      payload: T;
-      firstSeenAt: string;
-    }> = [];
-    for (const [id, createEvent] of this.contractMap.entries()) {
-      const ts = this.firstSeenAtMap.get(id) ?? new Date().toISOString();
-      out.push({
-        contractId: id,
-        payload: createEvent.payload,
-        firstSeenAt: ts,
-      });
-    }
-    return out;
+    return this.getAllEntriesWithMeta().map(({ contractId, data, firstSeenAt }) => ({
+      contractId,
+      payload: data,
+      firstSeenAt,
+    }));
   }
 
   public hasContract(contractId: ContractId<T>): boolean {
-    return this.contractMap.has(contractId);
+    return this.hasEntry(contractId);
   }
 
   public getContractCount(): number {
-    return this.contractMap.size;
+    return this.getEntryCount();
   }
 
   public getTemplateId(): PackageIdString {
-    return this.contractTemplate.templateId;
+    return this.getIdentifier();
   }
 
   public onCreated(key: string, callback: ContractCreatedCallback<T>): void {
-    if (this.createdCallbacks.has(key)) {
-      throw new Error(`Callback with key ${key} already exists`);
-    }
-    this.createdCallbacks.set(key, callback);
+    this.registerAddedCallback(key, callback);
   }
 
   public removeCreatedCallback(key: string): void {
-    this.createdCallbacks.delete(key);
+    this.removeAddedCallback(key);
   }
 
   public onArchived(key: string, callback: ContractArchivedCallback<T>): void {
-    if (this.archivedCallbacks.has(key)) {
-      throw new Error(`Callback with key ${key} already exists`);
-    }
-    this.archivedCallbacks.set(key, callback);
+    this.registerArchivedCallback(key, callback);
   }
 
   public removeArchivedCallback(key: string): void {
-    this.archivedCallbacks.delete(key);
+    this.removeRegisteredArchivedCallback(key);
   }
 
   public async handleContractCreated(createEvent: CreateEvent<T>): Promise<void> {
-    const { contractId, payload } = createEvent;
-
-    if (this.relevanceFn && !this.relevanceFn(payload)) {
-      this.logger.warn(`Ignoring irrelevant contract`, {
-        templateId: this.contractTemplate.templateId,
-        contractId: contractId.toString(),
-        payload,
-      });
-      return;
-    }
-
-    this.logger.debug(`Contract created`, {
-      templateId: this.contractTemplate.templateId,
-      contractId: contractId.toString(),
-    });
-
-    this.contractMap.set(contractId, createEvent);
-
-    if (!this.firstSeenAtMap.has(contractId)) {
-      this.firstSeenAtMap.set(contractId, new Date().toISOString());
-    }
-
-    for (const [, callback] of this.createdCallbacks) {
-      try {
-        await callback(contractId, payload, createEvent);
-      } catch (error) {
-        this.logger.error(
-          `Error executing created callback for ${this.contractTemplate.templateId}`,
-          error as Error,
-          { contractId: contractId.toString() }
-        );
-      }
-    }
+    return this.handleEventAdded(createEvent);
   }
 
   public async handleContractArchived(contractId: ContractId<T>): Promise<void> {
-    this.logger.debug(`Contract archived`, {
-      templateId: this.contractTemplate.templateId,
-      contractId: contractId.toString(),
-    });
-
-    const createEvent = this.contractMap.get(contractId);
-    if (createEvent) {
-      const payload = createEvent.payload;
-      this.contractMap.delete(contractId);
-      this.firstSeenAtMap.delete(contractId);
-
-      for (const [, callback] of this.archivedCallbacks) {
-        try {
-          await callback(contractId, payload);
-        } catch (error) {
-          this.logger.error(
-            `Error executing archived callback for ${this.contractTemplate.templateId}`,
-            error as Error,
-            { contractId: contractId.toString() }
-          );
-        }
-      }
-    }
-  }
-
-  public cleanup(): void {
-    this.contractMap.clear();
-    this.createdCallbacks.clear();
-    this.archivedCallbacks.clear();
+    return this.handleEventArchived(contractId);
   }
 }

--- a/server/src/acs/types.ts
+++ b/server/src/acs/types.ts
@@ -1,0 +1,81 @@
+import { ContractId, TemplateOrInterface } from "@daml/types";
+import { CreateEvent, PackageIdString } from "@c7-digital/ledger";
+
+/**
+ * Helper type to extract the payload type from a template or interface companion
+ */
+export type PayloadOf<TI> = TI extends TemplateOrInterface<infer P, any, any> ? P : never;
+
+/**
+ * Logger interface for ActiveContractsService.
+ * Matches the structured JSON logging pattern used by Canton apps.
+ */
+export interface AcsLogger {
+  debug(message: string, context?: Record<string, any>): void;
+  info(message: string, context?: Record<string, any>): void;
+  warn(message: string, context?: Record<string, any>): void;
+  error(message: string, error?: Error, context?: Record<string, any>): void;
+}
+
+/**
+ * No-op logger that discards all messages.
+ * Used as default when no logger is injected.
+ */
+export const noOpLogger: AcsLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+// Callback types for template trackers
+export type ContractCreatedCallback<T extends object> = (
+  contractId: ContractId<T>,
+  payload: T,
+  createEvent: CreateEvent<T>
+) => Promise<void> | void;
+
+export type ContractArchivedCallback<T extends object> = (
+  contractId: ContractId<T>,
+  payload: T
+) => Promise<void> | void;
+
+// Callback types for interface trackers
+export type InterfaceViewedCallback<I extends object> = (
+  contractId: ContractId<I>,
+  view: I,
+  interfaceEvent: import("@c7-digital/ledger").Interface<I>
+) => Promise<void> | void;
+
+export type InterfaceArchivedCallback<I extends object> = (
+  contractId: ContractId<I>,
+  view: I
+) => Promise<void> | void;
+
+/**
+ * Generic type for a contract with its ID and payload
+ */
+export type ContractWithPayload<T> = {
+  contractId: ContractId<T>;
+  payload: T;
+};
+
+// Type-safe tracker registry interface
+export interface TrackerRegistry {
+  has(templateId: PackageIdString): boolean;
+  get<T extends object>(templateId: PackageIdString): import("./templateTracker.js").TemplateTracker<T> | undefined;
+  set<T extends object>(templateId: PackageIdString, tracker: import("./templateTracker.js").TemplateTracker<T>): void;
+  length(): number;
+  values(): Iterable<import("./templateTracker.js").TemplateTracker<any>>;
+  keys(): Iterable<PackageIdString>;
+}
+
+// Type-safe interface tracker registry interface
+export interface InterfaceTrackerRegistry {
+  has(interfaceId: PackageIdString): boolean;
+  get<I extends object>(interfaceId: PackageIdString): import("./interfaceTracker.js").InterfaceTracker<I> | undefined;
+  set<I extends object>(interfaceId: PackageIdString, tracker: import("./interfaceTracker.js").InterfaceTracker<I>): void;
+  length(): number;
+  values(): Iterable<import("./interfaceTracker.js").InterfaceTracker<any>>;
+  keys(): Iterable<PackageIdString>;
+}

--- a/server/src/auth/apiAuth.ts
+++ b/server/src/auth/apiAuth.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+
+// Zod schemas for auth payloads
+const adminAuthPayloadSchema = z
+  .object({
+    type: z.literal("admin"),
+    apiKey: z.string().min(1, "API key cannot be empty"),
+  })
+  .strict();
+
+const contractAuthPayloadSchema = z
+  .object({
+    type: z.literal("contract"),
+    contractId: z.string().min(1, "Contract ID cannot be empty"),
+    party: z.string().min(1, "Party cannot be empty"),
+  })
+  .strict();
+
+// Discriminated union schema
+const authPayloadSchema = z.discriminatedUnion("type", [
+  adminAuthPayloadSchema,
+  contractAuthPayloadSchema,
+]);
+
+// Type inference from Zod schema
+export type AuthPayload = z.infer<typeof authPayloadSchema>;
+export type AdminAuthPayload = z.infer<typeof adminAuthPayloadSchema>;
+export type ContractAuthPayload = z.infer<typeof contractAuthPayloadSchema>;
+
+// Result type for auth operations
+export type AuthResult =
+  | { success: true; data: AuthPayload }
+  | { success: false; error: string };
+
+// Export schemas for external validation if needed
+export { authPayloadSchema, adminAuthPayloadSchema, contractAuthPayloadSchema };
+
+/**
+ * Validates and parses an auth payload object
+ */
+export function parseAuthPayload(rawPayload: unknown): AuthResult {
+  const result = authPayloadSchema.safeParse(rawPayload);
+  if (result.success) {
+    return { success: true, data: result.data };
+  } else {
+    const errors = result.error.errors.map(
+      (err) => `${err.path.join(".")}: ${err.message}`
+    );
+    return { success: false, error: `Validation failed: ${errors.join(", ")}` };
+  }
+}
+
+/**
+ * Browser-compatible base64 encoding
+ */
+function base64Encode(str: string): string {
+  if (typeof btoa !== "undefined") {
+    return btoa(str);
+  } else {
+    return Buffer.from(str, "utf-8").toString("base64");
+  }
+}
+
+/**
+ * Browser-compatible base64 decoding
+ */
+function base64Decode(str: string): string {
+  if (typeof atob !== "undefined") {
+    return atob(str);
+  } else {
+    return Buffer.from(str, "base64").toString("utf-8");
+  }
+}
+
+/**
+ * Encodes an auth payload to base64
+ */
+export function encodeAuthPayload(payload: AuthPayload): string {
+  const validatedPayload = authPayloadSchema.parse(payload);
+  const jsonString = JSON.stringify(validatedPayload);
+  return base64Encode(jsonString);
+}
+
+/**
+ * Decodes and validates a base64-encoded auth payload
+ */
+export function decodeAuthPayload(encodedPayload: string): AuthResult {
+  try {
+    const decoded = base64Decode(encodedPayload);
+    const rawPayload = JSON.parse(decoded);
+    return parseAuthPayload(rawPayload);
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, error: `Decode failed: ${error.message}` };
+    }
+    return { success: false, error: "Decode failed: Unknown error" };
+  }
+}
+
+/**
+ * Helper function to create admin authentication token
+ */
+export function createAdminAuth(apiKey: string): string {
+  const payload: AdminAuthPayload = { type: "admin", apiKey };
+  return encodeAuthPayload(payload);
+}
+
+/**
+ * Helper function to create contract-based authentication token
+ */
+export function createContractAuth(contractId: string, party: string): string {
+  const payload: ContractAuthPayload = { type: "contract", contractId, party };
+  return encodeAuthPayload(payload);
+}
+
+/**
+ * Type guards for auth payload types
+ */
+export function isAdminAuth(payload: AuthPayload): payload is AdminAuthPayload {
+  return payload.type === "admin";
+}
+
+export function isContractAuth(
+  payload: AuthPayload
+): payload is ContractAuthPayload {
+  return payload.type === "contract";
+}

--- a/server/src/auth/helpers.ts
+++ b/server/src/auth/helpers.ts
@@ -1,0 +1,42 @@
+import type { AuthResult, ContractAuthPayload } from "./apiAuth.js";
+import { decodeAuthPayload } from "./apiAuth.js";
+
+/**
+ * Extract auth payload from an HTTP request's Authorization header.
+ * Works with any request object that has a `headers.authorization` property.
+ */
+export function getAuthPayloadFromRequest(req: { headers: { authorization?: string } }): AuthResult {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return {
+      success: false,
+      error:
+        "Missing authorization header. Provide via Authorization: Bearer <base64-encoded-payload>",
+    };
+  }
+
+  try {
+    const encodedPayload = authHeader.slice(7); // Remove "Bearer "
+    return decodeAuthPayload(encodedPayload);
+  } catch (error) {
+    return {
+      success: false,
+      error: "Invalid authorization payload format. Must be valid base64-encoded JSON.",
+    };
+  }
+}
+
+// Discriminant union types for contract auth validation
+export type ContractAuthSuccess = {
+  success: true;
+  party: string;
+};
+
+export type ContractAuthFailure = {
+  success: false;
+  error: string;
+  party?: string;
+};
+
+export type ContractAuthResult = ContractAuthSuccess | ContractAuthFailure;

--- a/server/src/auth/index.ts
+++ b/server/src/auth/index.ts
@@ -1,0 +1,23 @@
+export {
+  type AuthPayload,
+  type AdminAuthPayload,
+  type ContractAuthPayload,
+  type AuthResult,
+  authPayloadSchema,
+  adminAuthPayloadSchema,
+  contractAuthPayloadSchema,
+  parseAuthPayload,
+  encodeAuthPayload,
+  decodeAuthPayload,
+  createAdminAuth,
+  createContractAuth,
+  isAdminAuth,
+  isContractAuth,
+} from "./apiAuth.js";
+
+export {
+  getAuthPayloadFromRequest,
+  type ContractAuthSuccess,
+  type ContractAuthFailure,
+  type ContractAuthResult,
+} from "./helpers.js";

--- a/server/src/identityService.ts
+++ b/server/src/identityService.ts
@@ -1,0 +1,310 @@
+import Keycloak, { KeycloakConfig as KeycloakConnectConfig } from "keycloak-connect";
+import { decodeJwt } from "jose";
+import type { KeycloakConfig, TokenUpdateCallback } from "./types.js";
+import type { Logger } from "./logger.js";
+import { sha256 } from "./sha256.js";
+
+interface KeycloakConfigWithCredentials extends KeycloakConnectConfig {
+  credentials: {
+    secret: string;
+  };
+}
+
+function hiddenKeycloakConfig(config: KeycloakConfigWithCredentials): KeycloakConfigWithCredentials {
+  const {
+    credentials: { secret },
+    ...restConfig
+  } = config;
+  const hashSecret = sha256(secret);
+  const encodedCredentials = { credentials: { secret: hashSecret } };
+  return { ...restConfig, ...encodedCredentials };
+}
+
+export class IdentityService {
+  private keycloak: Keycloak.Keycloak | null = null;
+  private keycloakConnectConfig: KeycloakConnectConfig | null = null;
+  private tokenRefreshTimer: NodeJS.Timeout | null = null;
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+  private nextRefreshTime: number | null = null;
+  private tokenUpdateCallbacks: Map<string, TokenUpdateCallback> = new Map();
+  private logger: Logger;
+  private keycloakConfig: KeycloakConfig;
+
+  // Internalized token state (replaces appState.ts)
+  private token: string | null = null;
+  private tokenExpiresIn: number = 0;
+
+  public isInitialized = false;
+
+  constructor(config: KeycloakConfig, logger: Logger) {
+    this.keycloakConfig = config;
+    this.logger = logger;
+  }
+
+  /**
+   * Get the current token
+   */
+  getToken(): string | null {
+    return this.token;
+  }
+
+  /**
+   * Get the current token expiration time in seconds
+   */
+  getTokenExpiresIn(): number {
+    return this.tokenExpiresIn;
+  }
+
+  /**
+   * Initialize with a static ledger token, bypassing Keycloak.
+   * Used for LocalNet testing where the token comes from Canton console.
+   */
+  async initWithStaticToken(staticToken: string): Promise<void> {
+    this.logger.info("Initializing Identity Service with static ledger token (Keycloak bypassed)");
+    this.token = staticToken;
+
+    const decoded = decodeJwt(staticToken);
+    const expiresIn = decoded.exp ? Math.floor(decoded.exp - Date.now() / 1000) : 3600;
+    this.tokenExpiresIn = expiresIn;
+
+    // Notify all registered callbacks (e.g., activeContractsService)
+    for (const [serviceId, callback] of this.tokenUpdateCallbacks.entries()) {
+      try {
+        await callback(staticToken);
+      } catch (error) {
+        this.logger.error(`Error in token update callback for ${serviceId}:`, error as Error);
+      }
+    }
+
+    this.isInitialized = true;
+    this.logger.warn(`Static token expires in ${expiresIn}s. Token will NOT auto-refresh. Re-run 'just local::init' for a fresh token.`);
+  }
+
+  /**
+   * Initialize the service and fetch the initial token
+   */
+  async init(): Promise<void> {
+    try {
+      this.keycloakConnectConfig = {
+        realm: this.keycloakConfig.realm,
+        "auth-server-url": this.keycloakConfig.url,
+        "ssl-required": "external",
+        resource: this.keycloakConfig.clientId,
+        "confidential-port": 0,
+        credentials: {
+          secret: this.keycloakConfig.clientSecret,
+        },
+      } as KeycloakConfigWithCredentials;
+
+      this.logger.debug("Keycloak config:", hiddenKeycloakConfig(this.keycloakConnectConfig as KeycloakConfigWithCredentials));
+      this.keycloak = new Keycloak({ store: {} }, this.keycloakConnectConfig);
+
+      this.logger.info("Initializing Identity Service...");
+      await this.fetchToken();
+      this.isInitialized = true;
+    } catch (error) {
+      this.logger.error("Failed to initialize Identity Service:", error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Register a callback to be called when the token is updated
+   */
+  onTokenUpdate(serviceId: string, callback: TokenUpdateCallback): void {
+    this.tokenUpdateCallbacks.set(serviceId, callback);
+  }
+
+  /**
+   * Remove a token update callback for a specific service
+   */
+  removeTokenUpdateCallback(serviceId: string): boolean {
+    return this.tokenUpdateCallbacks.delete(serviceId);
+  }
+
+  /**
+   * Get current number of registered token update callbacks
+   */
+  getCallbackCount(): number {
+    return this.tokenUpdateCallbacks.size;
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig() {
+    return {
+      url: this.keycloakConfig.url,
+      realm: this.keycloakConfig.realm,
+      clientId: this.keycloakConfig.clientId,
+    };
+  }
+
+  /**
+   * Get current status including next token refresh time
+   */
+  getStatus() {
+    return {
+      isInitialized: this.isInitialized,
+      nextRefreshTime: this.nextRefreshTime,
+      hasHeartbeat: this.heartbeatInterval !== null,
+      callbackCount: this.tokenUpdateCallbacks.size,
+      tokenExpiresIn: this.tokenExpiresIn,
+    };
+  }
+
+  /**
+   * Destroy the service and clean up resources
+   */
+  async destroy(): Promise<void> {
+    this.logger.info("Destroying Identity Service...");
+
+    this.stopHeartbeat();
+
+    if (this.tokenRefreshTimer) {
+      clearTimeout(this.tokenRefreshTimer);
+      this.tokenRefreshTimer = null;
+    }
+
+    this.nextRefreshTime = null;
+    this.token = "";
+    this.tokenExpiresIn = 0;
+    this.isInitialized = false;
+    this.keycloak = null;
+    this.keycloakConnectConfig = null;
+
+    this.logger.info("Identity Service destroyed");
+  }
+
+  /**
+   * Fetch a new token from Keycloak using Client Credentials (Service Account) flow
+   */
+  private async fetchToken(retries: number = 3, isScheduledRefresh: boolean = false): Promise<void> {
+    this.isInitialized = false;
+
+    const attemptFetch = async (attempt: number): Promise<void> => {
+      try {
+        if (!this.keycloak) {
+          this.logger.error("Keycloak not initialized");
+          return;
+        }
+
+        this.logger.debug(`Attempting to fetch token (attempt ${attempt}/${retries})`);
+
+        const grant = await this.keycloak.grantManager.obtainFromClientCredentials();
+
+        if (!grant || !grant.access_token) {
+          throw new Error("Failed to obtain token from Keycloak");
+        }
+
+        if (grant.isExpired()) {
+          if (attempt < retries) {
+            this.logger.info(`Token is expired, retrying (${retries - attempt} attempts remaining)...`);
+            await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+            return attemptFetch(attempt + 1);
+          } else {
+            throw new Error("Token is expired after all retries");
+          }
+        }
+
+        const accessToken = grant.access_token;
+        const newToken = (accessToken as any).token as string;
+        this.logger.debug(`New token:`, { token: newToken, payload: decodeJwt(newToken) });
+
+        this.tokenExpiresIn = parseInt(grant.expires_in ?? "0");
+
+        if (this.token !== newToken) {
+          this.token = newToken;
+
+          for (const [serviceId, callback] of this.tokenUpdateCallbacks.entries()) {
+            try {
+              await callback(newToken);
+            } catch (error) {
+              this.logger.error(
+                `Error in token update callback for service ${serviceId}:`,
+                error as Error
+              );
+            }
+          }
+
+          this.scheduleTokenRefresh(this.tokenExpiresIn);
+          this.logger.info("Successfully obtained Keycloak token");
+        } else {
+          this.logger.info("Same token, skipping update");
+        }
+        this.isInitialized = true;
+      } catch (error) {
+        this.logger.error(`Error fetching Keycloak token (attempt ${attempt}/${retries}):`, error as Error);
+
+        if (attempt < retries) {
+          const delay = Math.min(1000 * Math.pow(2, attempt), 5000);
+          this.logger.info(`Retrying token fetch in ${delay}ms...`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          return attemptFetch(attempt + 1);
+        } else {
+          if (isScheduledRefresh) {
+            this.logger.warn("Scheduled token refresh failed after all retries, will retry in 30 seconds");
+            this.scheduleTokenRefresh(30);
+          } else {
+            throw error;
+          }
+        }
+      }
+    };
+
+    await attemptFetch(1);
+  }
+
+  private scheduleTokenRefresh(expiresInSeconds: number): void {
+    if (this.tokenRefreshTimer) {
+      clearTimeout(this.tokenRefreshTimer);
+    }
+
+    const refreshInMs = Math.min((expiresInSeconds - 60) * 1000, (expiresInSeconds * 1000) / 2);
+    const safeRefreshMs = Math.max(refreshInMs, (expiresInSeconds - 30) * 1000);
+    const finalRefreshMs = Math.max(safeRefreshMs, 1000);
+
+    this.nextRefreshTime = Date.now() + finalRefreshMs;
+
+    this.logger.info(`Scheduling token refresh in ${finalRefreshMs / 1000} seconds (at ${new Date(this.nextRefreshTime).toISOString()})`);
+
+    this.tokenRefreshTimer = setTimeout(async () => {
+      this.nextRefreshTime = null;
+      await this.fetchToken(3, true);
+    }, finalRefreshMs);
+
+    this.startHeartbeat();
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      return;
+    }
+
+    this.heartbeatInterval = setInterval(() => {
+      if (this.nextRefreshTime && Date.now() >= this.nextRefreshTime) {
+        this.logger.warn(`Missed scheduled token refresh! Triggering now. Was scheduled for ${new Date(this.nextRefreshTime).toISOString()}`);
+        this.nextRefreshTime = null;
+
+        if (this.tokenRefreshTimer) {
+          clearTimeout(this.tokenRefreshTimer);
+          this.tokenRefreshTimer = null;
+        }
+
+        this.fetchToken(3, true).catch(err => {
+          this.logger.error("Heartbeat-triggered token refresh failed:", err);
+        });
+      }
+    }, 30000);
+
+    this.logger.debug("Token refresh heartbeat monitor started");
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+      this.logger.debug("Token refresh heartbeat monitor stopped");
+    }
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,26 @@
+export { IdentityService } from "./identityService.js";
+export { Logger, LedgerLoggerAdapter, type LogLevel, limitObjectDepth } from "./logger.js";
+export { sha256 } from "./sha256.js";
+export type { KeycloakConfig, TokenUpdateCallback } from "./types.js";
+
+// Active contracts service
+export {
+  ActiveContractsService,
+  type ActiveContractsServiceOptions,
+  TemplateTracker,
+  InterfaceTracker,
+  TypeSafeTrackerRegistry,
+  TypeSafeInterfaceTrackerRegistry,
+  noOpLogger,
+} from "./acs/index.js";
+export type {
+  PayloadOf,
+  AcsLogger,
+  ContractCreatedCallback,
+  ContractArchivedCallback,
+  InterfaceViewedCallback,
+  InterfaceArchivedCallback,
+  ContractWithPayload,
+  TrackerRegistry,
+  InterfaceTrackerRegistry,
+} from "./acs/index.js";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ export type { KeycloakConfig, TokenUpdateCallback } from "./types.js";
 export {
   ActiveContractsService,
   type ActiveContractsServiceOptions,
+  BaseTracker,
   TemplateTracker,
   InterfaceTracker,
   TypeSafeTrackerRegistry,

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,153 @@
+import { Logger as LedgerLogger } from "@c7-digital/ledger";
+
+export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+interface LogEntry {
+  "@timestamp": string;
+  level: LogLevel;
+  message: string;
+  [key: string]: any;
+}
+
+/**
+ * Limit the depth of an object to prevent deeply nested structures in logs
+ */
+function limitObjectDepth(obj: any, maxDepth: number = 6, currentDepth: number = 0): any {
+  if (currentDepth >= maxDepth) {
+    if (obj === null) return null;
+    if (typeof obj === 'object') {
+      if (Array.isArray(obj)) {
+        return `[Array(${obj.length})]`;
+      }
+      return `[Object(${Object.keys(obj).length} keys)]`;
+    }
+    return obj;
+  }
+
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => limitObjectDepth(item, maxDepth, currentDepth + 1));
+  }
+
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = limitObjectDepth(value, maxDepth, currentDepth + 1);
+  }
+  return result;
+}
+
+function formatLogEntry(
+  level: LogLevel,
+  message: string,
+  context?: Record<string, any>
+): string {
+  const limitedContext = context ? limitObjectDepth(context, 6) : undefined;
+
+  const logEntry: LogEntry = {
+    "@timestamp": new Date().toISOString(),
+    level,
+    message,
+    ...limitedContext,
+  };
+
+  return JSON.stringify(logEntry);
+}
+
+export class Logger {
+  debug(message: string, context?: Record<string, any>): void {
+    this.log("DEBUG", message, context);
+  }
+
+  info(message: string, context?: Record<string, any>): void {
+    this.log("INFO", message, context);
+  }
+
+  warn(message: string, context?: Record<string, any>): void {
+    this.log("WARN", message, context);
+  }
+
+  error(message: string, error?: Error, context?: Record<string, any>): void {
+    const errorContext = error
+      ? {
+          ...context,
+          error: {
+            message: error.message,
+            stack: error.stack,
+            name: error.name,
+          },
+        }
+      : context;
+
+    this.log("ERROR", message, errorContext);
+  }
+
+  private log(
+    level: LogLevel,
+    message: string,
+    context?: Record<string, any>
+  ): void {
+    const formattedLog = formatLogEntry(level, message, context);
+
+    if (level === "WARN" || level === "ERROR") {
+      process.stderr.write(formattedLog + "\n");
+    }
+
+    process.stdout.write(formattedLog + "\n");
+  }
+}
+
+/**
+ * Adapter class that implements the ledger Logger interface
+ * and forwards calls to the API's structured logger with "ledger" context
+ */
+export class LedgerLoggerAdapter implements LedgerLogger {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  debug(message: string, ...args: any[]): void {
+    this.logger.debug(message, { context: "ledger", args: this.formatArgs(args) });
+  }
+
+  info(message: string, ...args: any[]): void {
+    this.logger.info(message, { context: "ledger", args: this.formatArgs(args) });
+  }
+
+  warn(message: string, ...args: any[]): void {
+    this.logger.warn(message, { context: "ledger", args: this.formatArgs(args) });
+  }
+
+  error(message: string, ...args: any[]): void {
+    const error = args.find(arg => arg instanceof Error);
+    const otherArgs = args.filter(arg => !(arg instanceof Error));
+
+    if (error) {
+      this.logger.error(message, error, {
+        context: "ledger",
+        args: this.formatArgs(otherArgs),
+      });
+    } else {
+      this.logger.error(message, undefined, {
+        context: "ledger",
+        args: this.formatArgs(args),
+      });
+    }
+  }
+
+  log(message: string, ...args: any[]): void {
+    this.logger.info(message, { context: "ledger", args: this.formatArgs(args) });
+  }
+
+  private formatArgs(args: any[]): any {
+    if (args.length === 0) return undefined;
+    if (args.length === 1) return args[0];
+    return args;
+  }
+}
+
+export { limitObjectDepth };

--- a/server/src/sha256.ts
+++ b/server/src/sha256.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export function sha256(secret: string): string {
+  return crypto.createHash("sha256").update(secret).digest("hex");
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,8 @@
+export interface KeycloakConfig {
+  url: string;
+  realm: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export type TokenUpdateCallback = (token: string) => Promise<void>;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,5 +19,5 @@
     "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ES2020",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "composite": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Adds `@c7-digital/server`, a new shared package that extracts common server infrastructure into a reusable library.

### What's in the package

- **ActiveContractsService**: In-memory contract cache with MultiStream-based updates from Canton JSON API. Supports both template and interface trackers with type-safe registries, callback-based event
handling, and strong reference tracking to prevent GC.
- **IdentityService**: Keycloak token lifecycle management with auto-refresh, heartbeat monitoring, and static token mode for local development.
- **Logger**: Structured JSON logger with depth-limited serialization and a `LedgerLoggerAdapter` that bridges to `@c7-digital/ledger`'s logger interface.
- **Auth utilities** (`@c7-digital/server/auth`): Isomorphic auth payload encoding/decoding with Zod validation, supporting admin and contract auth types. Usable from both server and browser.
- **sha256**: Simple hashing utility.