### PR TITLE
move splice-codegen from peerDependency to dependency in scan

### DIFF
--- a/ledger/package.json
+++ b/ledger/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/ledger",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/ledger/src/websocket.ts
+++ b/ledger/src/websocket.ts
@@ -165,7 +165,8 @@ export class WebSocketClient {
 
         onMessage(message);
       } catch (error) {
-        onError?.(new Error(`Failed to parse message for ${endpoint}: ${error}`));
+        const errorDetail = error instanceof Error ? error.message : JSON.stringify(error);
+        onError?.(new Error(`Failed to parse message for ${endpoint}: ${errorDetail}`));
       }
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,16 +98,19 @@ importers:
 
   scan:
     dependencies:
-      '@c7-digital/splice-codegen':
-        specifier: workspace:*
-        version: link:../splice-codegen
       '@daml/types':
         specifier: 3.4.9
         version: 3.4.9
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
       cross-fetch:
         specifier: ^3.2.0
         version: 3.2.0
     devDependencies:
+      '@c7-digital/splice-codegen':
+        specifier: workspace:*
+        version: link:../splice-codegen
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
 
   scan:
     dependencies:
+      '@c7-digital/splice-codegen':
+        specifier: workspace:*
+        version: link:../splice-codegen
       '@daml/types':
         specifier: 3.4.9
         version: 3.4.9
@@ -105,9 +108,6 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
     devDependencies:
-      '@c7-digital/splice-codegen':
-        specifier: workspace:*
-        version: link:../splice-codegen
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
     devDependencies:
-      '@c7-digital/splice-codegen':
-        specifier: workspace:*
-        version: link:../splice-codegen
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c7-digital/react",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "React hooks for Daml ledger integration using Canton JSON API v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scan/package.json
+++ b/scan/package.json
@@ -21,13 +21,13 @@
     "build": "tsx scripts/build.ts --splice-version=0.5.10",
     "compile": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
     "watch": "tsc --watch",
-    "clean": "rm -rf lib src/generated",
+    "clean": "rm -rf lib src/generated lib/_vendor",
     "prepare": "pnpm build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
   },
   "dependencies": {
-    "@c7-digital/splice-codegen": "workspace:*",
     "@daml/types": "3.4.9",
+    "@mojotech/json-type-validation": "^3.1.0",
     "cross-fetch": "^3.2.0"
   },
   "engines": {
@@ -35,6 +35,7 @@
     "pnpm": ">=8.0.0"
   },
   "devDependencies": {
+    "@c7-digital/splice-codegen": "workspace:*",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.15.11",
     "jest": "^29.7.0",

--- a/scan/package.json
+++ b/scan/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/scan",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/scan/package.json
+++ b/scan/package.json
@@ -26,18 +26,15 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
   },
   "dependencies": {
+    "@c7-digital/splice-codegen": "workspace:*",
     "@daml/types": "3.4.9",
     "cross-fetch": "^3.2.0"
-  },
-  "peerDependencies": {
-    "@c7-digital/splice-codegen": "*"
   },
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
   },
   "devDependencies": {
-    "@c7-digital/splice-codegen": "workspace:*",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.15.11",
     "jest": "^29.7.0",

--- a/scan/package.json
+++ b/scan/package.json
@@ -35,7 +35,6 @@
     "pnpm": ">=8.0.0"
   },
   "devDependencies": {
-    "@c7-digital/splice-codegen": "workspace:*",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.15.11",
     "jest": "^29.7.0",

--- a/scan/scripts/build.ts
+++ b/scan/scripts/build.ts
@@ -15,7 +15,7 @@ import { join, dirname, relative, sep } from "path";
 import { fileURLToPath } from "url";
 import { exec } from "child_process";
 import { promisify } from "util";
-import { writeFile, mkdir, readdir, readFile, cp } from "fs/promises";
+import { writeFile, mkdir, readdir, readFile, cp, unlink } from "fs/promises";
 import { existsSync } from "fs";
 
 const execAsync = promisify(exec);
@@ -182,11 +182,28 @@ async function embedSpliceCodegen(): Promise<void> {
   await cp(scribeDir, vendorDir, { recursive: true, dereference: true });
   console.log(`Copied .scribe/ → ${vendorDir}`);
 
+  // Remove nested package.json files — they contain dependencies on
+  // @c7-digital/splice-codegen/* that would confuse pnpm during install.
+  // Only .d.ts files are needed for type resolution.
+  await removeNestedPackageJsons(vendorDir);
+
   // Rewrite @c7-digital/splice-codegen imports in all .d.ts files under lib/
   const libDir = join(projectRoot, "lib");
   await rewriteImportsInDir(libDir, vendorDir);
 
   console.log("splice-codegen types embedded successfully.");
+}
+
+async function removeNestedPackageJsons(dir: string): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await removeNestedPackageJsons(fullPath);
+    } else if (entry.name === "package.json" || entry.name === "tsconfig.json" || entry.name.endsWith(".js")) {
+      await unlink(fullPath);
+    }
+  }
 }
 
 /**

--- a/scan/scripts/build.ts
+++ b/scan/scripts/build.ts
@@ -185,7 +185,7 @@ async function embedSpliceCodegen(): Promise<void> {
   // Remove nested package.json files — they contain dependencies on
   // @c7-digital/splice-codegen/* that would confuse pnpm during install.
   // Only .d.ts files are needed for type resolution.
-  await removeNestedPackageJsons(vendorDir);
+  await removeNonTsFiles(vendorDir);
 
   // Rewrite @c7-digital/splice-codegen imports in all .d.ts files under lib/
   const libDir = join(projectRoot, "lib");
@@ -194,12 +194,12 @@ async function embedSpliceCodegen(): Promise<void> {
   console.log("splice-codegen types embedded successfully.");
 }
 
-async function removeNestedPackageJsons(dir: string): Promise<void> {
+async function removeNonTsFiles(dir: string): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
-      await removeNestedPackageJsons(fullPath);
+      await removeNonTsFiles(fullPath);
     } else if (entry.name === "package.json" || entry.name === "tsconfig.json" || entry.name.endsWith(".js")) {
       await unlink(fullPath);
     }

--- a/scan/scripts/build.ts
+++ b/scan/scripts/build.ts
@@ -11,11 +11,11 @@
  * 5. Compile TypeScript (tsc + tsc-alias)
  */
 
-import { join, dirname } from "path";
+import { join, dirname, relative, sep } from "path";
 import { fileURLToPath } from "url";
 import { exec } from "child_process";
 import { promisify } from "util";
-import { writeFile, mkdir, readdir } from "fs/promises";
+import { writeFile, mkdir, readdir, readFile, cp } from "fs/promises";
 import { existsSync } from "fs";
 
 const execAsync = promisify(exec);
@@ -161,6 +161,69 @@ async function compileTypeScript(): Promise<void> {
   }
 }
 
+async function embedSpliceCodegen(): Promise<void> {
+  console.log("Embedding splice-codegen types...");
+
+  const spliceCodegenRoot = join(projectRoot, "node_modules", "@c7-digital", "splice-codegen");
+  const scribeDir = join(spliceCodegenRoot, ".scribe");
+  const vendorDir = join(projectRoot, "lib", "_vendor", "splice-codegen");
+
+  if (!existsSync(scribeDir)) {
+    throw new Error(`splice-codegen .scribe directory not found at ${scribeDir}`);
+  }
+
+  // Copy .scribe/ into lib/_vendor/splice-codegen/ (dereference symlinks)
+  await cp(scribeDir, vendorDir, { recursive: true, dereference: true });
+  console.log(`Copied .scribe/ → ${vendorDir}`);
+
+  // Rewrite @c7-digital/splice-codegen imports in all .d.ts files under lib/
+  const libDir = join(projectRoot, "lib");
+  await rewriteImportsInDir(libDir, vendorDir);
+
+  console.log("splice-codegen types embedded successfully.");
+}
+
+/**
+ * Recursively find .d.ts files and rewrite @c7-digital/splice-codegen imports
+ * to relative paths pointing into _vendor/splice-codegen/.
+ */
+async function rewriteImportsInDir(dir: string, vendorDir: string): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await rewriteImportsInDir(fullPath, vendorDir);
+    } else if (entry.name.endsWith(".d.ts")) {
+      let content = await readFile(fullPath, "utf-8");
+      if (!content.includes("@c7-digital/splice-codegen")) continue;
+
+      content = content.replace(
+        /from\s+(['"])@c7-digital\/splice-codegen(?:\/([^'"]*))?\1/g,
+        (_match, quote, subpath) => {
+          const fileDir = dirname(fullPath);
+          if (subpath) {
+            // Subpath import: @c7-digital/splice-codegen/MODULE_NAME
+            // Resolves to vendorDir/MODULE_NAME/lib/index
+            const target = join(vendorDir, subpath, "lib", "index");
+            let rel = relative(fileDir, target).split(sep).join("/");
+            if (!rel.startsWith(".")) rel = "./" + rel;
+            return `from ${quote}${rel}${quote}`;
+          } else {
+            // Root import: @c7-digital/splice-codegen
+            // Resolves to vendorDir/index
+            const target = join(vendorDir, "index");
+            let rel = relative(fileDir, target).split(sep).join("/");
+            if (!rel.startsWith(".")) rel = "./" + rel;
+            return `from ${quote}${rel}${quote}`;
+          }
+        }
+      );
+
+      await writeFile(fullPath, content, "utf-8");
+    }
+  }
+}
+
 async function build(): Promise<void> {
   console.log("Starting @c7-digital/scan build...\n");
 
@@ -178,6 +241,9 @@ async function build(): Promise<void> {
 
     // Compile TypeScript (depends on generated types)
     await compileTypeScript();
+
+    // Embed splice-codegen types into lib/ so consumers don't need it installed
+    await embedSpliceCodegen();
 
     console.log(`\nBuild completed successfully for Splice version: ${version}`);
   } catch (error) {

--- a/scan/scripts/build.ts
+++ b/scan/scripts/build.ts
@@ -164,12 +164,18 @@ async function compileTypeScript(): Promise<void> {
 async function embedSpliceCodegen(): Promise<void> {
   console.log("Embedding splice-codegen types...");
 
-  const spliceCodegenRoot = join(projectRoot, "node_modules", "@c7-digital", "splice-codegen");
-  const scribeDir = join(spliceCodegenRoot, ".scribe");
+  // Look for splice-codegen's .scribe/ in multiple locations:
+  // 1. Sibling workspace directory (../splice-codegen/.scribe)
+  // 2. node_modules (when installed as a dependency)
+  const candidates = [
+    join(projectRoot, "..", "splice-codegen", ".scribe"),
+    join(projectRoot, "node_modules", "@c7-digital", "splice-codegen", ".scribe"),
+  ];
+  const scribeDir = candidates.find(d => existsSync(d));
   const vendorDir = join(projectRoot, "lib", "_vendor", "splice-codegen");
 
-  if (!existsSync(scribeDir)) {
-    throw new Error(`splice-codegen .scribe directory not found at ${scribeDir}`);
+  if (!scribeDir) {
+    throw new Error(`splice-codegen .scribe directory not found. Searched:\n${candidates.join("\n")}`);
   }
 
   // Copy .scribe/ into lib/_vendor/splice-codegen/ (dereference symlinks)

--- a/scan/tsconfig.json
+++ b/scan/tsconfig.json
@@ -17,7 +17,10 @@
     "noUncheckedIndexedAccess": true,
     "composite": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "paths": {
+      "@c7-digital/splice-codegen": ["../splice-codegen/.scribe/index.d.ts"]
+    }
   },
   "include": ["src", "scripts"],
   "exclude": ["node_modules", "lib"],


### PR DESCRIPTION
splice-codegen is an implementation detail of scan, not something consumers should install separately. As a regular dependency it resolves automatically when scan is consumed from the workspace or via GitHub refs.