### PR TITLE
Expose getTopProvidersByAppRewards

### DIFF
--- a/scan/package.json
+++ b/scan/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/scan",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/scan/src/client.ts
+++ b/scan/src/client.ts
@@ -228,6 +228,12 @@ type GetRoundOfLatestDataOperation = operations["getRoundOfLatestData"];
 type GetRoundOfLatestDataResponse =
   GetRoundOfLatestDataOperation["responses"]["200"]["content"]["application/json"];
 
+type GetTopProvidersByAppRewardsOperation = operations["getTopProvidersByAppRewards"];
+type GetTopProvidersByAppRewardsParams =
+  GetTopProvidersByAppRewardsOperation["parameters"]["query"];
+type GetTopProvidersByAppRewardsResponse =
+  GetTopProvidersByAppRewardsOperation["responses"]["200"]["content"]["application/json"];
+
 // ─── Migrations ────────────────────────────────────────────────────────
 
 type MigrationScheduleResponse =
@@ -714,6 +720,16 @@ export class ScanClient {
       "/v0/round-party-totals",
       "POST",
       { body },
+    );
+  }
+
+  async getTopProvidersByAppRewards(
+    params: GetTopProvidersByAppRewardsParams,
+  ): Promise<GetTopProvidersByAppRewardsResponse> {
+    return this.request<GetTopProvidersByAppRewardsResponse>(
+      "/v0/top-providers-by-app-rewards",
+      "GET",
+      { query: params as Record<string, unknown> },
     );
   }
 


### PR DESCRIPTION
Add typed wrapper for `GET /v0/top-providers-by-app-rewards` endpoint. Returns cumulative app rewards per provider party, which is needed for the featured app view.

Apparently forgot to add this in the previous PR #23.