### PR TITLE
Prefix tarball paths with ./ so npm treats them as files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,9 @@ jobs:
       - name: Publish tarballs
         run: |
           set -euo pipefail
-          for tarball in packed/*.tgz; do
+          # Prefix with ./ — bare "packed/foo.tgz" matches npm's <owner>/<repo>
+          # GitHub shorthand and npm will try to clone it instead of publishing it.
+          for tarball in ./packed/*.tgz; do
             echo "::group::Publishing $tarball"
             npm publish "$tarball" --access public --provenance
             echo "::endgroup::"


### PR DESCRIPTION
Without the prefix, "packed/foo.tgz" matches npm's <owner>/<repo> GitHub shorthand pattern and npm tries to git-clone it instead of publishing it.