### PR TITLE
auth: clamp watchdog setTimeout to int32 ceiling, keep creds on opaqu…

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c7-digital/react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "React hooks for Daml ledger integration using Canton JSON API v2",
   "repository": {
     "type": "git",

--- a/react/src/auth/AuthProvider.test.tsx
+++ b/react/src/auth/AuthProvider.test.tsx
@@ -616,6 +616,80 @@ describe("AuthProvider — JWT exp watchdog", () => {
 
     expect(screen.getByTestId("party").textContent).toBe("none");
   });
+
+  it("clamps msUntilExpiry to the setTimeout int32 ceiling for long-lived tokens", async () => {
+    // Regression: an access token with TTL > 2^31-1 ms (≈ 24.855 days) would
+    // overflow setTimeout's internal int32 and fire on the next macrotask,
+    // wiping a brand-new credential. The derive effect would re-create the
+    // same credential, the watchdog would re-overflow, and the LoginScreen
+    // would loop with no error surfaced. Hit by a customer's Auth0 tenant
+    // configured for a 30-day Access Token Lifetime. The clamp caps the
+    // delay; on its expiry the CAS finds the same token still in play and
+    // the next render's watchdog schedules a fresh, shorter delay.
+    const TIMER_MAX_MS = 2_147_483_647;
+    const recordedDelays: number[] = [];
+    const origSetTimeout = window.setTimeout;
+    const setTimeoutSpy = vi
+      .spyOn(window, "setTimeout")
+      .mockImplementation(((cb: () => void, delay?: number) => {
+        // The watchdog's delay is in the seconds-to-days range; ignore React's
+        // microtask shims and other short timers.
+        if (typeof delay === "number" && delay > 1000) {
+          recordedDelays.push(delay);
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        }
+        return origSetTimeout(cb, delay);
+      }) as typeof setTimeout);
+
+    try {
+      const now = Date.now();
+      const tokenExp30Days = makeJwt({
+        sub: "alice",
+        exp: Math.floor(now / 1000) + 30 * 24 * 60 * 60, // +30 days
+      });
+      const creds: Credentials = {
+        party: "alice::long",
+        token: tokenExp30Days,
+        user: { primaryParty: "alice::long" } as never,
+        source: "oidc",
+      };
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(creds));
+
+      renderProvider();
+
+      // Credentials survive: a pre-clamp build would null `party` here
+      // because the overflowed timer fired in the same tick.
+      expect(screen.getByTestId("party").textContent).toBe("alice::long");
+      expect(recordedDelays).toHaveLength(1);
+      expect(recordedDelays[0]).toBe(TIMER_MAX_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("leaves credentials in place when the token is not a parseable JWT", async () => {
+    // The watchdog's `try { decodeJwt(...) } catch { ... }` used to wipe
+    // credentials on parse failure, which (a) contradicted the block's own
+    // comment ("opaque tokens are assumed to be managed elsewhere") and (b)
+    // looped the LoginScreen if the IdP issued an opaque access_token the
+    // participant nevertheless accepted. The catch is now a bare return.
+    const creds: Credentials = {
+      party: "alice::opaque",
+      token: "opaque-reference-token-not-a-jwt",
+      user: { primaryParty: "alice::opaque" } as never,
+      source: "oidc",
+    };
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(creds));
+
+    renderProvider();
+    // Give effects a tick to run.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(screen.getByTestId("party").textContent).toBe("alice::opaque");
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
 });
 
 describe("AuthProvider — sessionStorage persistence", () => {

--- a/react/src/auth/AuthProvider.tsx
+++ b/react/src/auth/AuthProvider.tsx
@@ -54,6 +54,12 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 const DEFAULT_STORAGE_KEY = "auth_credentials";
 
+// Maximum delay setTimeout accepts before its internal signed-int32
+// truncates the value and the callback fires immediately. The exp
+// watchdog clamps against this; see the comment in the watchdog effect
+// for the loop-on-overflow scenario.
+const TIMER_MAX_MS = 2_147_483_647;
+
 const readStoredCredentials = (storageKey: string): Credentials | null => {
   if (typeof window === "undefined") return null;
   try {
@@ -292,7 +298,6 @@ const CredentialsProvider: React.FC<{
     try {
       exp = decodeJwt(credentials.token).exp;
     } catch {
-      setCredentials(null);
       return;
     }
     if (typeof exp !== "number") return;
@@ -308,12 +313,29 @@ const CredentialsProvider: React.FC<{
     // if the timer's macrotask was already queued by the runtime before
     // commit (long synchronous work, GC pause), it'd otherwise nuke a
     // freshly-rotated token. CAS makes that a no-op.
+    //
+    // Clamp the delay to the int32 ceiling. Every browser engine (and
+    // Node) stores setTimeout's delay as a signed 32-bit integer; any
+    // value > 2^31-1 ms (~24.855 days) overflows and the callback fires
+    // immediately. Without this clamp, a long-lived access token (e.g.
+    // an Auth0 API with a 30-day Access Token Lifetime) would have the
+    // watchdog wipe credentials on the next macrotask, the derive effect
+    // would re-create the same credentials, and the wipe would re-fire
+    // — looping the LoginScreen with no error surfaced. When the real
+    // exp is further out than the clamp, the timer fires at the clamp,
+    // finds the token still in play, and credentialsRef-CAS skips the
+    // wipe; the next render schedules a fresh, shorter delay against
+    // the still-valid token, repeating until exp falls inside the int32
+    // window.
     const scheduledToken = credentials.token;
-    const timer = setTimeout(() => {
-      if (credentialsRef.current?.token === scheduledToken) {
-        setCredentials(null);
-      }
-    }, msUntilExpiry);
+    const timer = setTimeout(
+      () => {
+        if (credentialsRef.current?.token === scheduledToken) {
+          setCredentials(null);
+        }
+      },
+      Math.min(msUntilExpiry, TIMER_MAX_MS),
+    );
     return () => clearTimeout(timer);
   }, [credentials, setCredentials]);
 


### PR DESCRIPTION
…e tokens

The JWT exp watchdog handed `msUntilExpiry` straight to `setTimeout`. Browser engines store the delay as a signed-int32 — any value > 2^31-1 ms (~24.855 days) overflows and fires immediately. An Auth0 tenant configured with a 30-day Access Token Lifetime therefore loops the LoginScreen: derive → set credentials → watchdog overflow → wipe → re-derive → loop. Clamp the delay to TIMER_MAX_MS; the CAS guard already handles "timer fires but token still in play."

Also fix the long-standing decodeJwt-catch wipe: the block's own comment says "opaque tokens are assumed to be managed elsewhere," but the catch nulled credentials — so an IdP issuing an opaque access_token the participant nevertheless accepted would loop identically. Bare return matches the documented intent.

Two regression tests added in the JWT exp watchdog describe block.

Bump 0.0.22 → 0.0.23.