### PR TITLE
Export createEventsFromWire for off-Ledger wire→CreateEvent decoding

### DIFF
--- a/ledger/package.json
+++ b/ledger/package.json
@@ -8,7 +8,7 @@
   "files": [
     "lib",
     "lib-lite",
-    "spec",
+    "specs",
     "scripts",
     "BUILD.md"
   ],

--- a/ledger/package.json
+++ b/ledger/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/ledger",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/ledger/src/api-surface.test.ts
+++ b/ledger/src/api-surface.test.ts
@@ -41,6 +41,7 @@ describe("Public API surface", () => {
   it.each([
     "createCmd",
     "createAndExerciseCmd",
+    "createEventsFromWire",
     "exerciseCmd",
     "setLogger",
     "toDisclosedContract",

--- a/ledger/src/index.ts
+++ b/ledger/src/index.ts
@@ -1,5 +1,15 @@
 // Main export for the new ledger package
-export { Ledger, type LedgerOptions, type HistoryEvent, createCmd, createAndExerciseCmd, exerciseCmd, convertCommand } from "./ledger";
+export {
+  Ledger,
+  type LedgerOptions,
+  type HistoryEvent,
+  type ActiveContractsRow,
+  createCmd,
+  createAndExerciseCmd,
+  createEventsFromWire,
+  exerciseCmd,
+  convertCommand,
+} from "./ledger";
 export { TypedHttpClient, type TypedHttpClientConfig, LedgerApiError } from "./client";
 export {
   WebSocketClient,

--- a/ledger/src/ledger.ts
+++ b/ledger/src/ledger.ts
@@ -174,11 +174,11 @@ function createEvent_<T extends object, K = unknown>(
  *
  * Filters and logs in one pass:
  *   - Non-active-contract entries (`JsEmpty` / `JsIncompleteAssigned` /
- *     `JsIncompleteUnassigned`) are dropped silently at debug level.
+ *     `JsIncompleteUnassigned`) are dropped with a `debug`-level log.
  *   - If `expectedTemplateId` is provided, rows whose
  *     `createdEvent.templateId` doesn't match it under
- *     {@link matchesPartiallyQualified} are dropped at warn level —
- *     mirrors {@link Ledger.query}'s diagnostic so the same triage
+ *     {@link matchesPartiallyQualified} are dropped with a `warn`-level
+ *     log — mirrors {@link Ledger.query}'s diagnostic so the same triage
  *     signal is preserved when callers go off-Ledger.
  *
  * Use this when consuming ACS responses obtained from a transport that

--- a/ledger/src/ledger.ts
+++ b/ledger/src/ledger.ts
@@ -86,6 +86,15 @@ type CreatedEvent = Schemas["CreatedEvent"];
 type ArchivedEvent = Schemas["ArchivedEvent"];
 type JsInterfaceView = Schemas["JsInterfaceView"];
 
+/**
+ * One entry of the array returned by `POST /v2/state/active-contracts`.
+ * Aliases the OpenAPI-generated `JsGetActiveContractsResponse` schema as
+ * a public, stable name so callers consuming raw ACS rows from a
+ * non-`Ledger` transport (e.g. dapp-sdk's `canton_ledgerApi` proxy)
+ * don't have to reach into the codegen namespace.
+ */
+export type ActiveContractsRow = Schemas["JsGetActiveContractsResponse"];
+
 // Type guard to check if an event is a CreatedEvent
 function isCreateEvent(
   event: Schemas["Event"]
@@ -156,6 +165,57 @@ function createEvent_<T extends object, K = unknown>(
     packageVersion,
     nodeId: cantonEvent.nodeId,
   };
+}
+
+/**
+ * Convert an array of {@link ActiveContractsRow}s (the response body of
+ * `POST /v2/state/active-contracts`) into typed, value.proto-branded
+ * {@link CreateEvent}s.
+ *
+ * Filters and logs in one pass:
+ *   - Non-active-contract entries (`JsEmpty` / `JsIncompleteAssigned` /
+ *     `JsIncompleteUnassigned`) are dropped silently at debug level.
+ *   - If `expectedTemplateId` is provided, rows whose
+ *     `createdEvent.templateId` doesn't match it under
+ *     {@link matchesPartiallyQualified} are dropped at warn level —
+ *     mirrors {@link Ledger.query}'s diagnostic so the same triage
+ *     signal is preserved when callers go off-Ledger.
+ *
+ * Use this when consuming ACS responses obtained from a transport that
+ * gave you raw rows but bypassed {@link Ledger.query} — e.g. dapp-sdk's
+ * CIP-0103 `canton_ledgerApi` proxy in wallet/proxied mode. You get the
+ * same decoded `CreateEvent<T>` shape (decoder-applied payload,
+ * synchronizerId carried through) without reimplementing the inner
+ * conversion.
+ */
+export function createEventsFromWire<T extends object, K = unknown>(
+  rows: ActiveContractsRow[],
+  versionedRegistry?: VersionedRegistry,
+  expectedTemplateId?: string,
+): CreateEvent<T, K>[] {
+  const out: CreateEvent<T, K>[] = [];
+  for (const row of rows) {
+    if (!row.contractEntry || !("JsActiveContract" in row.contractEntry)) {
+      logger.debug(`Skipping non-active contract entry: ${JSON.stringify(row.contractEntry)}`);
+      continue;
+    }
+    const active = row.contractEntry.JsActiveContract;
+    const created = active.createdEvent;
+    if (
+      expectedTemplateId !== undefined &&
+      !matchesPartiallyQualified(
+        created.templateId as IdentifierString,
+        expectedTemplateId
+      )
+    ) {
+      logger.warn(
+        `Template ID mismatch: expected ${expectedTemplateId}, got ${created.templateId}`
+      );
+      continue;
+    }
+    out.push(createEvent_<T, K>(created, versionedRegistry, active.synchronizerId));
+  }
+  return out;
 }
 
 function archiveEvent_<T extends object>(cantonEvent: ArchivedEvent): ArchiveEvent<T> {
@@ -1178,33 +1238,13 @@ export class Ledger {
 
     const response = await this.client.queryActiveContracts(queryRequest);
 
-    // Convert the response to our CreateEvent format
-    return response.reduce(
-      (acc: CreateEvent<T, K>[], item: Schemas["JsGetActiveContractsResponse"]) => {
-        // Skip non-active contract entries
-        if (!item.contractEntry || !("JsActiveContract" in item.contractEntry)) {
-          logger.debug(`Skipping non-active contract entry: ${JSON.stringify(item.contractEntry)}`);
-          return acc;
-        }
-
-        const contractEntry = item.contractEntry as {
-          JsActiveContract: Schemas["JsActiveContract"];
-        };
-        const createEvent = contractEntry.JsActiveContract.createdEvent;
-        const synchronizerId = contractEntry.JsActiveContract.synchronizerId;
-
-        // Verify we got the correct template
-        if (!matchesPartiallyQualified(createEvent.templateId, template.templateId)) {
-          logger.warn(
-            `Template ID mismatch: expected ${template.templateId}, got ${createEvent.templateId}`
-          );
-          return acc; // Skip contracts with mismatched template IDs
-        }
-
-        acc.push(createEvent_(createEvent, this.options.versionedRegistry, synchronizerId));
-        return acc;
-      },
-      []
+    // Wire→domain mapping lives in `createEventsFromWire` so consumers
+    // of the wallet proxy (dapp-sdk's `canton_ledgerApi`) apply the same
+    // decoder path without re-entering this `Ledger` instance.
+    return createEventsFromWire<T, K>(
+      response,
+      this.options.versionedRegistry,
+      template.templateId,
     );
   }
 


### PR DESCRIPTION
Lift the inner `JsGetActiveContractsResponse[] → CreateEvent<T>[]` conversion that lived inside `Ledger.query`'s reduce loop into a standalone public function. Consumers receiving ACS rows from a transport other than this `Ledger` instance — e.g. dapp-sdk's CIP-0103 `canton_ledgerApi` proxy when a wallet runs in WC-only mode and exposes no `network.ledgerApi` — can now decode rows into the same value.proto-branded `CreateEvent<T>` shape, instead of hand-rolling a partial copy that misses the decoder step, the synchronizerId carry-through, and the packageVersion stamp.

`Ledger.query` is refactored to delegate to `createEventsFromWire` and preserves the prior per-reason diagnostic logging (`non-active-contract entry` at debug, `templateId mismatch` at warn) — both moved inside the helper so the same triage signal fires for off-Ledger consumers too. External behaviour of `Ledger.query` is unchanged.

Also exports `ActiveContractsRow` as a public alias for `Schemas["JsGetActiveContractsResponse"]` so off-Ledger callers can type their wire-row arrays without reaching into the codegen namespace.