### PR TITLE
Extract decodeExerciseResult; export apiComponents

### DIFF
--- a/ledger/package.json
+++ b/ledger/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/ledger",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/ledger/src/exerciseResult.ts
+++ b/ledger/src/exerciseResult.ts
@@ -1,0 +1,67 @@
+// Shared helper for extracting a choice's decoded return value out of a
+// `TRANSACTION_SHAPE_LEDGER_EFFECTS` response.
+//
+// Callers submit the exercise with `transactionShape = LEDGER_EFFECTS`
+// (see {@link Ledger.exerciseResult}), then hand this helper the resulting
+// event list — either from the participant's `submitAndWaitForTransaction`
+// response or from a downstream `POST /v2/updates/update-by-id` fetch (the
+// path a wallet-mode dApp takes because CIP-0103's
+// `prepare_execute_and_wait` returns only `{updateId, completionOffset}`).
+//
+// Both transports produce the same `components["schemas"]["Event"][]` shape
+// — an ArchivedEvent / CreatedEvent / ExercisedEvent variant — so the walk
+// factors cleanly out of `Ledger.exerciseResult` and is reused verbatim by
+// `@c7-private/dapp-stack`'s `ExternalPartySession.exerciseResult`.
+
+import type { Choice, ContractId } from "@daml/types";
+import { components } from "./generated/api";
+
+/**
+ * Locate the root `ExercisedEvent` matching `(choice, contractId)` in
+ * `events`, and decode its `exerciseResult` via `choice.resultDecoder`.
+ *
+ * `events` MUST come from a submission or update-fetch made with
+ * `TRANSACTION_SHAPE_LEDGER_EFFECTS`; the default `ACS_DELTA` shape drops
+ * `ExercisedEvent`s (they're not create/archive events) and this helper
+ * will then throw a "no matching ExercisedEvent" error.
+ *
+ * "Root exercise" = the choice we submitted. Match by `(choice.choiceName,
+ * contractId)` so a future change that surfaces child exercises (a Daml
+ * choice that internally exercises another choice) doesn't pick up the
+ * wrong result.
+ *
+ * @throws if the LEDGER_EFFECTS response contains no matching
+ *         `ExercisedEvent`, or the matching event has no `exerciseResult`.
+ *         Both indicate the transport returned an unexpected shape.
+ */
+export function decodeExerciseResult<T extends object, C, R, K = unknown>(
+  events: readonly components["schemas"]["Event"][],
+  choice: Choice<T, C, R, K>,
+  contractId: ContractId<T>
+): R {
+  const contractIdStr = contractId.toString();
+  for (const event of events) {
+    if ("ExercisedEvent" in event) {
+      const ee = event.ExercisedEvent;
+      if (
+        ee.choice === choice.choiceName &&
+        ee.contractId === contractIdStr
+      ) {
+        if (ee.exerciseResult === undefined) {
+          throw new Error(
+            `exerciseResult: LEDGER_EFFECTS response for ` +
+              `${choice.template().templateId}::${choice.choiceName} ` +
+              `has no exerciseResult — the server returned an unexpected shape.`
+          );
+        }
+        return choice.resultDecoder.runWithException(ee.exerciseResult);
+      }
+    }
+  }
+  throw new Error(
+    `exerciseResult: no matching ExercisedEvent for ` +
+      `${choice.template().templateId}::${choice.choiceName} ` +
+      `on contract ${contractIdStr}. The submission may have used a ` +
+      `transaction shape that does not include exercise nodes.`
+  );
+}

--- a/ledger/src/exerciseResult.ts
+++ b/ledger/src/exerciseResult.ts
@@ -14,7 +14,7 @@
 // `@c7-private/dapp-stack`'s `ExternalPartySession.exerciseResult`.
 
 import type { Choice, ContractId } from "@daml/types";
-import { components } from "./generated/api";
+import type { components } from "./generated/api";
 
 /**
  * Locate the root `ExercisedEvent` matching `(choice, contractId)` in

--- a/ledger/src/index.ts
+++ b/ledger/src/index.ts
@@ -26,5 +26,15 @@ export { type Logger, ConsoleLogger, NoOpLogger, logger, setLogger } from "./log
 export * from "./types";
 export * from "./events";
 export * from "./valueTypes";
+export { decodeExerciseResult } from "./exerciseResult";
+
+// Re-export the JSON Ledger API OpenAPI schemas so consumers can name
+// wire-response shapes (`components["schemas"]["Event"]`,
+// `["JsGetUpdateResponse"]`, etc.) without redeclaring slivers. Used by
+// `@c7-private/dapp-stack`'s `ExternalPartySession` to type the wallet-
+// proxied `sdk.ledgerApi(...)` response before handing it to
+// {@link decodeExerciseResult}. `apiComponents` mirrors the local alias
+// used in `types.ts`.
+export type { components as apiComponents } from "./generated/api";
 
 export { SDK_VERSION } from "./generated/sdk-version";

--- a/ledger/src/index.ts
+++ b/ledger/src/index.ts
@@ -29,7 +29,7 @@ export * from "./valueTypes";
 export { decodeExerciseResult } from "./exerciseResult";
 
 // Re-export the JSON Ledger API OpenAPI schemas so consumers can name
-// wire-response shapes (`components["schemas"]["Event"]`,
+// wire-response shapes (`apiComponents["schemas"]["Event"]`,
 // `["JsGetUpdateResponse"]`, etc.) without redeclaring slivers. Used by
 // `@c7-private/dapp-stack`'s `ExternalPartySession` to type the wallet-
 // proxied `sdk.ledgerApi(...)` response before handing it to

--- a/ledger/src/ledger.ts
+++ b/ledger/src/ledger.ts
@@ -27,6 +27,7 @@ import {
 import { EventEmitter } from "eventemitter3";
 import { logger } from "./logger";
 import { logTokenExpiration } from "./token";
+import { decodeExerciseResult } from "./exerciseResult";
 import { components } from "./generated/api";
 import { TypedHttpClient } from "./client";
 import {
@@ -1543,36 +1544,10 @@ export class Ledger {
     };
     const request = { commands, transactionFormat };
     const response = await this.client.submitAndWaitForTransaction(request);
-    const events = response.transaction.events || [];
-
-    for (const event of events) {
-      if ("ExercisedEvent" in event) {
-        const ee = event.ExercisedEvent;
-        // Root exercise = the one we submitted. Match by (choice,
-        // contractId) so a future change that surfaces child
-        // exercises (Daml choices that internally exercise other
-        // choices) doesn't pick up the wrong result.
-        if (
-          ee.choice === choice.choiceName &&
-          ee.contractId === contractId.toString()
-        ) {
-          if (ee.exerciseResult === undefined) {
-            throw new Error(
-              `exerciseResult: LEDGER_EFFECTS response for ` +
-                `${choice.template().templateId}::${choice.choiceName} ` +
-                `has no exerciseResult — the server returned an unexpected shape.`
-            );
-          }
-          return choice.resultDecoder.runWithException(ee.exerciseResult);
-        }
-      }
-    }
-
-    throw new Error(
-      `exerciseResult: no matching ExercisedEvent for ` +
-        `${choice.template().templateId}::${choice.choiceName} ` +
-        `on contract ${contractId}. The submission may have used a ` +
-        `transaction shape that does not include exercise nodes.`
+    return decodeExerciseResult(
+      response.transaction.events || [],
+      choice,
+      contractId
     );
   }
 


### PR DESCRIPTION
## Summary
- New exported `decodeExerciseResult(events, choice, contractId): R` in `ledger/src/exerciseResult.ts` — factors out the walk that `Ledger.exerciseResult` did inline (find root `ExercisedEvent` by `(choice, contractId)`, throw if `exerciseResult` is undefined, decode via `choice.resultDecoder`).
- `Ledger.exerciseResult` now delegates to it (~30 lines removed).
- Re-exports the OpenAPI schemas namespace as `apiComponents` from the entry — so consumers can name wire shapes (`apiComponents[\"schemas\"][\"JsGetUpdateResponse\"]`, `[\"Event\"]`, etc.) without redeclaring slivers or reaching for the deep-import-blocked `./generated/api` path.

## Why
Wallet-mode dApps in `@c7-private/dapp-stack` need the same walk. CIP-0103's `prepare_execute_and_wait` returns only `{updateId, completionOffset}`, so the tree has to be fetched via `POST /v2/updates/update-by-id` and walked identically. Extracting the helper here means both call sites share one implementation instead of a shape-mirrored copy.

## Follow-up
`@c7-private/dapp-stack` PR #3 will import `decodeExerciseResult` + `apiComponents` and replace its local wire-schema redeclarations.

## Test plan
- [x] `pnpm run build` clean — both `lib/` and `lib-lite/` compile; both index.d.ts variants re-export the new helper + `apiComponents`.
- [x] `pnpm test` — existing `Ledger.exerciseResult` tests still pass (behavior unchanged, just moved code).