### PR TITLE
Add a `default` export condition so CommonJS consumers can resolve

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/admin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/admin/package.json
+++ b/admin/package.json
@@ -12,8 +12,9 @@
   "description": "TypeScript client for the Canton participant admin gRPC API",
   "exports": {
     ".": {
+      "types": "./lib/src/index.d.ts",
       "import": "./lib/src/index.js",
-      "types": "./lib/src/index.d.ts"
+      "default": "./lib/src/index.js"
     }
   },
   "scripts": {

--- a/ledger/package.json
+++ b/ledger/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/ledger",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/ledger/package.json
+++ b/ledger/package.json
@@ -20,16 +20,19 @@
   },
   "exports": {
     ".": {
+      "types": "./lib/src/index.d.ts",
       "import": "./lib/src/index.js",
-      "types": "./lib/src/index.d.ts"
+      "default": "./lib/src/index.js"
     },
     "./lite": {
+      "types": "./lib-lite/src/index.d.ts",
       "import": "./lib-lite/src/index.js",
-      "types": "./lib-lite/src/index.d.ts"
+      "default": "./lib-lite/src/index.js"
     },
     "./sets": {
+      "types": "./lib/src/sets.d.ts",
       "import": "./lib/src/sets.js",
-      "types": "./lib/src/sets.d.ts"
+      "default": "./lib/src/sets.js"
     }
   },
   "bin": {

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c7-digital/react",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "React hooks for Daml ledger integration using Canton JSON API v2",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@c7-digital/ledger": ">=0.0.17 <0.1.0",
+    "@c7-digital/ledger": "^0.0.32",
     "@daml/types": ">=3.4.0 <4.0.0",
     "react": "^18.0.0",
     "react-oidc-context": "^3.3.0",

--- a/scan/package.json
+++ b/scan/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/scan",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/scan/package.json
+++ b/scan/package.json
@@ -18,8 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./lib/src/index.d.ts",
       "import": "./lib/src/index.js",
-      "types": "./lib/src/index.d.ts"
+      "default": "./lib/src/index.js"
     }
   },
   "scripts": {

--- a/scribe/package.json
+++ b/scribe/package.json
@@ -16,12 +16,14 @@
   ],
   "exports": {
     ".": {
+      "types": "./lib/src/index.d.ts",
       "import": "./lib/src/index.js",
-      "types": "./lib/src/index.d.ts"
+      "default": "./lib/src/index.js"
     },
     "./vite": {
+      "types": "./lib/src/vite-plugin.d.ts",
       "import": "./lib/src/vite-plugin.js",
-      "types": "./lib/src/vite-plugin.d.ts"
+      "default": "./lib/src/vite-plugin.js"
     }
   },
   "bin": {

--- a/scribe/package.json
+++ b/scribe/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@c7-digital/scribe",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "description": "Transform DAML codegen output into unified TypeScript packages for use with @c7-digital/ledger",
   "repository": {


### PR DESCRIPTION
Every subpath in these four packages offered only `import` and `types`. Node picks conditions per resolution mode, and the CJS set is `require`/`node`/ `default` — so with no `default`, any CommonJS consumer fails resolution outright, with the misleading `ERR_PACKAGE_PATH_NOT_EXPORTED` ("subpath is not defined by exports") even though the subpath is plainly there. The subpath is defined; nothing matched.

This is not hypothetical. `@c7-private/dapp-stack` declares no `"type"`, so it is CommonJS, and it imports `@c7-digital/ledger/lite`. Anything that loads dapp-stack outside a bundler — a Node test, a script — dies on that import. It cost c7lock an entire test file (apps/shared/src/ui/amulet.test.ts crashes before a single test runs) and the same seam surfaced twice more during recent SLC work.

`react` and `splice-codegen` already carried `default`; this brings admin, ledger, scan and scribe in line with them:

  admin   .
  ledger  .  ./lite  ./sets
  scan    .
  scribe  .  ./vite

`default` points at the same ESM entry as `import` — Node 22+ supports `require()` of ES modules, so a CJS consumer loads the identical file rather than needing a separate CJS build. Verified with a CommonJS probe: all three ledger subpaths resolve, where all three previously failed.

Condition ORDER matters and is now uniform: `types`, `import`, `default`. Node takes the first match, so `default` must come last or it shadows every more specific condition; TypeScript wants `types` first. The old entries had `import` before `types`, which worked only because the two never collide.

No runtime code changes — these are manifest-only edits, so consumers pick it up on the next publish.